### PR TITLE
[TASK] Message, ChatRoom 도메인 모델 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/common/util/generator/PrimaryKeyGenerator.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/common/util/generator/PrimaryKeyGenerator.java
@@ -1,0 +1,12 @@
+package com.teambind.co.kr.chatdding.common.util.generator;
+
+/**
+ * Primary Key Generator Interface
+ */
+public interface PrimaryKeyGenerator {
+
+    Long generateLongKey();
+
+    @Deprecated(since = "1.1", forRemoval = false)
+    String generateKey();
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoom.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoom.java
@@ -1,0 +1,221 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 채팅방 Aggregate Root
+ *
+ * <p>채팅방의 생성, 참여자 관리, 상태 변경 등 핵심 비즈니스 로직을 캡슐화</p>
+ */
+@Getter
+public class ChatRoom {
+
+    private final RoomId id;
+    private final ChatRoomType type;
+    private String name;
+    private final List<Participant> participants;
+    private final UserId ownerId;
+    private ChatRoomStatus status;
+    private final LocalDateTime createdAt;
+    private LocalDateTime lastMessageAt;
+
+    private ChatRoom(RoomId id, ChatRoomType type, String name,
+                     List<Participant> participants, UserId ownerId,
+                     ChatRoomStatus status, LocalDateTime createdAt,
+                     LocalDateTime lastMessageAt) {
+        this.id = id;
+        this.type = type;
+        this.name = name;
+        this.participants = new ArrayList<>(participants);
+        this.ownerId = ownerId;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.lastMessageAt = lastMessageAt;
+    }
+
+    /**
+     * DM 채팅방 생성
+     *
+     * @param id          Snowflake로 생성된 RoomId (Application Layer에서 주입)
+     * @param senderId    발신자 ID
+     * @param recipientId 수신자 ID
+     */
+    public static ChatRoom createDm(RoomId id, UserId senderId, UserId recipientId) {
+        List<Participant> participants = List.of(
+                Participant.create(senderId),
+                Participant.create(recipientId)
+        );
+
+        LocalDateTime now = LocalDateTime.now();
+        return new ChatRoom(
+                id,
+                ChatRoomType.DM,
+                null,
+                participants,
+                senderId,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now
+        );
+    }
+
+    /**
+     * 그룹 채팅방 생성
+     *
+     * @param id        Snowflake로 생성된 RoomId (Application Layer에서 주입)
+     * @param ownerId   방장 ID
+     * @param memberIds 멤버 ID 목록
+     * @param name      채팅방 이름
+     */
+    public static ChatRoom createGroup(RoomId id, UserId ownerId, List<UserId> memberIds, String name) {
+        if (memberIds.size() + 1 > ChatRoomType.GROUP.getMaxParticipants()) {
+            throw ChatException.of(ErrorCode.GROUP_MAX_PARTICIPANTS_EXCEEDED);
+        }
+
+        List<Participant> participants = new ArrayList<>();
+        participants.add(Participant.create(ownerId));
+        memberIds.forEach(memberId -> participants.add(Participant.create(memberId)));
+
+        LocalDateTime now = LocalDateTime.now();
+        return new ChatRoom(
+                id,
+                ChatRoomType.GROUP,
+                name,
+                participants,
+                ownerId,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now
+        );
+    }
+
+    /**
+     * 고객 상담 채팅방 생성
+     *
+     * @param id     Snowflake로 생성된 RoomId (Application Layer에서 주입)
+     * @param userId 사용자 ID
+     */
+    public static ChatRoom createSupport(RoomId id, UserId userId) {
+        List<Participant> participants = List.of(Participant.create(userId));
+
+        LocalDateTime now = LocalDateTime.now();
+        return new ChatRoom(
+                id,
+                ChatRoomType.SUPPORT,
+                null,
+                participants,
+                userId,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now
+        );
+    }
+
+    /**
+     * 기존 데이터로부터 ChatRoom 복원 (Repository용)
+     */
+    public static ChatRoom restore(RoomId id, ChatRoomType type, String name,
+                                    List<Participant> participants, UserId ownerId,
+                                    ChatRoomStatus status, LocalDateTime createdAt,
+                                    LocalDateTime lastMessageAt) {
+        return new ChatRoom(id, type, name, participants, ownerId, status, createdAt, lastMessageAt);
+    }
+
+    /**
+     * 참여자 목록 (불변)
+     */
+    public List<Participant> getParticipants() {
+        return Collections.unmodifiableList(participants);
+    }
+
+    /**
+     * 참여자 ID 목록
+     */
+    public List<UserId> getParticipantIds() {
+        return participants.stream()
+                .map(Participant::getUserId)
+                .toList();
+    }
+
+    /**
+     * 정렬된 참여자 ID 목록 (DM 중복 체크용)
+     */
+    public List<Long> getSortedParticipantIdValues() {
+        return getParticipantIds().stream()
+                .map(UserId::getValue)
+                .sorted()
+                .toList();
+    }
+
+    /**
+     * 참여자 여부 확인
+     */
+    public boolean isParticipant(UserId userId) {
+        return participants.stream()
+                .anyMatch(p -> p.getUserId().equals(userId));
+    }
+
+    /**
+     * 참여자 조회
+     */
+    public Optional<Participant> findParticipant(UserId userId) {
+        return participants.stream()
+                .filter(p -> p.getUserId().equals(userId))
+                .findFirst();
+    }
+
+    /**
+     * 마지막 메시지 시간 업데이트
+     */
+    public void updateLastMessageAt(LocalDateTime messageCreatedAt) {
+        if (messageCreatedAt != null) {
+            this.lastMessageAt = messageCreatedAt;
+        }
+    }
+
+    /**
+     * 채팅방 이름 변경 (GROUP만 가능)
+     */
+    public void changeName(String newName) {
+        if (type != ChatRoomType.GROUP) {
+            throw new IllegalStateException("Only GROUP chat room can change name");
+        }
+        this.name = newName;
+    }
+
+    /**
+     * 상담원 배정 (SUPPORT만 가능)
+     */
+    public void assignAgent(UserId agentId) {
+        if (type != ChatRoomType.SUPPORT) {
+            throw new IllegalStateException("Only SUPPORT chat room can assign agent");
+        }
+        if (participants.size() >= ChatRoomType.SUPPORT.getMaxParticipants()) {
+            throw new IllegalStateException("Agent already assigned");
+        }
+        participants.add(Participant.create(agentId));
+    }
+
+    /**
+     * 채팅방 종료
+     */
+    public void close() {
+        this.status = ChatRoomStatus.CLOSED;
+    }
+
+    /**
+     * 활성 상태 여부
+     */
+    public boolean isActive() {
+        return status.isActive();
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomStatus.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomStatus.java
@@ -1,0 +1,21 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채팅방 상태
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomStatus {
+
+    ACTIVE("활성"),
+    CLOSED("종료");
+
+    private final String description;
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomType.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomType.java
@@ -1,0 +1,23 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채팅방 유형
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomType {
+
+    DM("1:1 개인 대화", 2),
+    GROUP("그룹 채팅", 100),
+    SUPPORT("고객 상담", 2);
+
+    private final String description;
+    private final int maxParticipants;
+
+    public boolean canAddParticipant(int currentCount) {
+        return currentCount < maxParticipants;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/Participant.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/Participant.java
@@ -1,0 +1,59 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 채팅방 참여자 Value Object
+ *
+ * <p>채팅방 내 참여자의 설정 및 상태를 관리</p>
+ */
+@Getter
+public class Participant {
+
+    private final UserId userId;
+    private boolean notificationEnabled;
+    private LocalDateTime lastReadAt;
+    private final LocalDateTime joinedAt;
+
+    private Participant(UserId userId, boolean notificationEnabled,
+                        LocalDateTime lastReadAt, LocalDateTime joinedAt) {
+        this.userId = userId;
+        this.notificationEnabled = notificationEnabled;
+        this.lastReadAt = lastReadAt;
+        this.joinedAt = joinedAt;
+    }
+
+    public static Participant create(UserId userId) {
+        LocalDateTime now = LocalDateTime.now();
+        return new Participant(userId, true, now, now);
+    }
+
+    public static Participant of(UserId userId, boolean notificationEnabled,
+                                  LocalDateTime lastReadAt, LocalDateTime joinedAt) {
+        return new Participant(userId, notificationEnabled, lastReadAt, joinedAt);
+    }
+
+    public void updateLastReadAt(LocalDateTime readAt) {
+        if (readAt != null && (this.lastReadAt == null || readAt.isAfter(this.lastReadAt))) {
+            this.lastReadAt = readAt;
+        }
+    }
+
+    public void enableNotification() {
+        this.notificationEnabled = true;
+    }
+
+    public void disableNotification() {
+        this.notificationEnabled = false;
+    }
+
+    public boolean hasUnreadMessages(LocalDateTime lastMessageAt) {
+        if (lastMessageAt == null) {
+            return false;
+        }
+        return lastReadAt == null || lastMessageAt.isAfter(lastReadAt);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/RoomId.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/RoomId.java
@@ -1,0 +1,46 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import com.teambind.co.kr.chatdding.domain.common.DomainId;
+
+/**
+ * 채팅방 ID Value Object
+ *
+ * <p>Snowflake ID 기반, DB에는 Long 저장, API에서는 String으로 변환</p>
+ *
+ * @param value 채팅방 ID 값 (Snowflake Long)
+ */
+public record RoomId(Long value) implements DomainId<Long> {
+
+    public RoomId {
+        if (value == null) {
+            throw new IllegalArgumentException("RoomId value cannot be null");
+        }
+        if (value <= 0) {
+            throw new IllegalArgumentException("RoomId value must be positive: " + value);
+        }
+    }
+
+    public static RoomId of(Long value) {
+        return new RoomId(value);
+    }
+
+    /**
+     * String에서 RoomId 생성 (API 요청 파싱용)
+     */
+    public static RoomId fromString(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("RoomId string value cannot be null or blank");
+        }
+        return new RoomId(Long.parseLong(value));
+    }
+
+    @Override
+    public Long getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/common/DomainId.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/common/DomainId.java
@@ -1,0 +1,21 @@
+package com.teambind.co.kr.chatdding.domain.common;
+
+/**
+ * 도메인 ID의 공통 인터페이스
+ *
+ * <p>모든 도메인 ID는 이 인터페이스를 구현</p>
+ * <p>DB에는 Long으로 저장, API 요청/응답에서는 String으로 변환</p>
+ *
+ * @param <T> ID 값의 타입
+ */
+public interface DomainId<T> {
+
+    T getValue();
+
+    /**
+     * API 응답용 String 변환
+     */
+    default String toStringValue() {
+        return String.valueOf(getValue());
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/common/UserId.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/common/UserId.java
@@ -1,0 +1,34 @@
+package com.teambind.co.kr.chatdding.domain.common;
+
+/**
+ * 사용자 ID Value Object
+ *
+ * <p>다른 서비스(Auth, Profile)에서 발급된 사용자 ID를 래핑</p>
+ *
+ * @param value 사용자 ID 값 (양수)
+ */
+public record UserId(Long value) implements DomainId<Long> {
+
+    public UserId {
+        if (value == null) {
+            throw new IllegalArgumentException("UserId value cannot be null");
+        }
+        if (value <= 0) {
+            throw new IllegalArgumentException("UserId value must be positive: " + value);
+        }
+    }
+
+    public static UserId of(Long value) {
+        return new UserId(value);
+    }
+
+    @Override
+    public Long getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/message/Message.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/message/Message.java
@@ -1,0 +1,166 @@
+package com.teambind.co.kr.chatdding.domain.message;
+
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 메시지 Aggregate Root
+ *
+ * <p>메시지의 생성, 읽음 처리, 삭제 등 핵심 비즈니스 로직을 캡슐화</p>
+ */
+@Getter
+public class Message {
+
+    private static final int MAX_CONTENT_LENGTH = 5000;
+
+    private final MessageId id;
+    private final RoomId roomId;
+    private final UserId senderId;
+    private final String content;
+    private final Map<UserId, LocalDateTime> readBy;
+    private final Set<UserId> deletedBy;
+    private final LocalDateTime createdAt;
+
+    private Message(MessageId id, RoomId roomId, UserId senderId, String content,
+                    Map<UserId, LocalDateTime> readBy, Set<UserId> deletedBy,
+                    LocalDateTime createdAt) {
+        this.id = id;
+        this.roomId = roomId;
+        this.senderId = senderId;
+        this.content = content;
+        this.readBy = new HashMap<>(readBy);
+        this.deletedBy = new HashSet<>(deletedBy);
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * 새 메시지 생성
+     *
+     * @param id       Snowflake로 생성된 MessageId (Application Layer에서 주입)
+     * @param roomId   채팅방 ID
+     * @param senderId 발신자 ID
+     * @param content  메시지 내용
+     */
+    public static Message create(MessageId id, RoomId roomId, UserId senderId, String content) {
+        validateContent(content);
+
+        Map<UserId, LocalDateTime> readBy = new HashMap<>();
+        LocalDateTime now = LocalDateTime.now();
+        readBy.put(senderId, now);
+
+        return new Message(
+                id,
+                roomId,
+                senderId,
+                content,
+                readBy,
+                new HashSet<>(),
+                now
+        );
+    }
+
+    /**
+     * 기존 데이터로부터 Message 복원 (Repository용)
+     */
+    public static Message restore(MessageId id, RoomId roomId, UserId senderId, String content,
+                                   Map<UserId, LocalDateTime> readBy, Set<UserId> deletedBy,
+                                   LocalDateTime createdAt) {
+        return new Message(id, roomId, senderId, content, readBy, deletedBy, createdAt);
+    }
+
+    private static void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw ChatException.of(ErrorCode.MESSAGE_CONTENT_EMPTY);
+        }
+        if (content.length() > MAX_CONTENT_LENGTH) {
+            throw ChatException.of(ErrorCode.MESSAGE_CONTENT_TOO_LONG);
+        }
+    }
+
+    /**
+     * 읽음 처리
+     */
+    public void markAsRead(UserId userId) {
+        if (!readBy.containsKey(userId)) {
+            readBy.put(userId, LocalDateTime.now());
+        }
+    }
+
+    /**
+     * 특정 시간으로 읽음 처리 (배치 처리용)
+     */
+    public void markAsReadAt(UserId userId, LocalDateTime readAt) {
+        if (!readBy.containsKey(userId)) {
+            readBy.put(userId, readAt);
+        }
+    }
+
+    /**
+     * 메시지 삭제 (사용자별 소프트 삭제)
+     */
+    public void deleteFor(UserId userId) {
+        deletedBy.add(userId);
+    }
+
+    /**
+     * 특정 사용자가 이 메시지를 읽었는지 확인
+     */
+    public boolean isReadBy(UserId userId) {
+        return readBy.containsKey(userId);
+    }
+
+    /**
+     * 특정 사용자에게 삭제된 메시지인지 확인
+     */
+    public boolean isDeletedFor(UserId userId) {
+        return deletedBy.contains(userId);
+    }
+
+    /**
+     * 특정 사용자에게 보여줄 수 있는 메시지인지 확인
+     */
+    public boolean isVisibleTo(UserId userId) {
+        return !isDeletedFor(userId);
+    }
+
+    /**
+     * 읽음 상태 맵 (불변)
+     */
+    public Map<UserId, LocalDateTime> getReadBy() {
+        return Collections.unmodifiableMap(readBy);
+    }
+
+    /**
+     * 삭제한 사용자 목록 (불변)
+     */
+    public Set<UserId> getDeletedBy() {
+        return Collections.unmodifiableSet(deletedBy);
+    }
+
+    /**
+     * 메시지 미리보기 (알림용)
+     */
+    public String getContentPreview() {
+        if (content.length() <= 50) {
+            return content;
+        }
+        return content.substring(0, 50) + "...";
+    }
+
+    /**
+     * 읽은 사용자 수
+     */
+    public int getReadCount() {
+        return readBy.size();
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/message/MessageId.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/message/MessageId.java
@@ -1,0 +1,46 @@
+package com.teambind.co.kr.chatdding.domain.message;
+
+import com.teambind.co.kr.chatdding.domain.common.DomainId;
+
+/**
+ * 메시지 ID Value Object
+ *
+ * <p>Snowflake ID 기반, DB에는 Long 저장, API에서는 String으로 변환</p>
+ *
+ * @param value 메시지 ID 값 (Snowflake Long)
+ */
+public record MessageId(Long value) implements DomainId<Long> {
+
+    public MessageId {
+        if (value == null) {
+            throw new IllegalArgumentException("MessageId value cannot be null");
+        }
+        if (value <= 0) {
+            throw new IllegalArgumentException("MessageId value must be positive: " + value);
+        }
+    }
+
+    public static MessageId of(Long value) {
+        return new MessageId(value);
+    }
+
+    /**
+     * String에서 MessageId 생성 (API 요청 파싱용)
+     */
+    public static MessageId fromString(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("MessageId string value cannot be null or blank");
+        }
+        return new MessageId(Long.parseLong(value));
+    }
+
+    @Override
+    public Long getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}


### PR DESCRIPTION
## Summary
- DomainId 인터페이스 정의 (Long DB 저장, String API 변환)
- UserId, RoomId, MessageId Value Object 구현 (Snowflake 기반)
- ChatRoomType, ChatRoomStatus 열거형 구현
- Participant Value Object 구현 (채팅방 참여자)
- ChatRoom Aggregate Root 구현 (DM, Group, Support 팩토리 메서드)
- Message Aggregate Root 구현 (읽음 처리, 삭제 기능)
- Snowflake ID 생성기 추가

## Changes
| 파일 | 설명 |
|------|------|
| `DomainId.java` | 도메인 ID 공통 인터페이스 |
| `UserId.java` | 사용자 ID Value Object |
| `RoomId.java` | 채팅방 ID Value Object |
| `MessageId.java` | 메시지 ID Value Object |
| `ChatRoomType.java` | 채팅방 유형 (DM, GROUP, SUPPORT) |
| `ChatRoomStatus.java` | 채팅방 상태 (ACTIVE, CLOSED) |
| `Participant.java` | 채팅방 참여자 Value Object |
| `ChatRoom.java` | 채팅방 Aggregate Root |
| `Message.java` | 메시지 Aggregate Root |
| `Snowflake.java` | Snowflake ID 생성기 |

## Test plan
- [ ] 빌드 성공 확인 (./gradlew build)
- [ ] 도메인 모델 단위 테스트 (다음 태스크에서 추가)

Resolves #7