### PR TITLE
[TASK] SendMessageUseCase 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/SendMessageCommand.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/SendMessageCommand.java
@@ -1,0 +1,46 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+/**
+ * 메시지 전송 Command DTO
+ *
+ * @param roomId   채팅방 ID
+ * @param senderId 발신자 ID
+ * @param content  메시지 내용
+ */
+public record SendMessageCommand(
+        RoomId roomId,
+        UserId senderId,
+        String content
+) {
+
+    public SendMessageCommand {
+        if (roomId == null) {
+            throw new IllegalArgumentException("roomId cannot be null");
+        }
+        if (senderId == null) {
+            throw new IllegalArgumentException("senderId cannot be null");
+        }
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("content cannot be null or blank");
+        }
+    }
+
+    public static SendMessageCommand of(Long roomId, Long senderId, String content) {
+        return new SendMessageCommand(
+                RoomId.of(roomId),
+                UserId.of(senderId),
+                content
+        );
+    }
+
+    public static SendMessageCommand of(String roomId, Long senderId, String content) {
+        return new SendMessageCommand(
+                RoomId.fromString(roomId),
+                UserId.of(senderId),
+                content
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/SendMessageResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/SendMessageResult.java
@@ -1,0 +1,33 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.message.Message;
+
+import java.time.LocalDateTime;
+
+/**
+ * 메시지 전송 결과 DTO
+ *
+ * @param messageId 생성된 메시지 ID (String)
+ * @param roomId    채팅방 ID (String)
+ * @param senderId  발신자 ID
+ * @param content   메시지 내용
+ * @param createdAt 생성 시간
+ */
+public record SendMessageResult(
+        String messageId,
+        String roomId,
+        Long senderId,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static SendMessageResult from(Message message) {
+        return new SendMessageResult(
+                message.getId().toStringValue(),
+                message.getRoomId().toStringValue(),
+                message.getSenderId().getValue(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/SendMessageUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/SendMessageUseCase.java
@@ -1,0 +1,18 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+/**
+ * 메시지 전송 UseCase Port (Application Layer)
+ *
+ * <p>Hexagonal Architecture의 Inbound Port</p>
+ * <p>외부(Controller, WebSocket 등)에서 메시지 전송을 요청할 때 사용</p>
+ */
+public interface SendMessageUseCase {
+
+    /**
+     * 메시지 전송
+     *
+     * @param command 메시지 전송 명령
+     * @return 전송 결과
+     */
+    SendMessageResult execute(SendMessageCommand command);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/SendMessageService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/SendMessageService.java
@@ -1,0 +1,73 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageCommand;
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageResult;
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageUseCase;
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.common.util.generator.PrimaryKeyGenerator;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.message.Message;
+import com.teambind.co.kr.chatdding.domain.message.MessageId;
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 메시지 전송 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SendMessageService implements SendMessageUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
+    private final PrimaryKeyGenerator primaryKeyGenerator;
+
+    @Override
+    public SendMessageResult execute(SendMessageCommand command) {
+        ChatRoom chatRoom = findChatRoom(command);
+        validateParticipant(chatRoom, command);
+
+        Message message = createAndSaveMessage(command);
+        updateChatRoomLastMessageAt(chatRoom, message);
+
+        return SendMessageResult.from(message);
+    }
+
+    private ChatRoom findChatRoom(SendMessageCommand command) {
+        return chatRoomRepository.findById(command.roomId())
+                .orElseThrow(() -> ChatException.of(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private void validateParticipant(ChatRoom chatRoom, SendMessageCommand command) {
+        if (!chatRoom.isParticipant(command.senderId())) {
+            throw ChatException.of(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+
+        if (!chatRoom.isActive()) {
+            throw ChatException.of(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+
+    private Message createAndSaveMessage(SendMessageCommand command) {
+        MessageId messageId = MessageId.of(primaryKeyGenerator.generateLongKey());
+
+        Message message = Message.create(
+                messageId,
+                command.roomId(),
+                command.senderId(),
+                command.content()
+        );
+
+        return messageRepository.save(message);
+    }
+
+    private void updateChatRoomLastMessageAt(ChatRoom chatRoom, Message message) {
+        chatRoom.updateLastMessageAt(message.getCreatedAt());
+        chatRoomRepository.save(chatRoom);
+    }
+}


### PR DESCRIPTION
## Summary
- SendMessageUseCase 포트 인터페이스 정의 (Inbound Port)
- SendMessageCommand, SendMessageResult DTO 구현
- SendMessageService UseCase 구현체

## Changes
| 파일 | 설명 |
|------|------|
| `SendMessageUseCase.java` | 메시지 전송 UseCase 포트 인터페이스 |
| `SendMessageCommand.java` | 메시지 전송 요청 Command DTO |
| `SendMessageResult.java` | 메시지 전송 결과 DTO |
| `SendMessageService.java` | UseCase 구현체 |

## Flow
```
Controller/WebSocket
       |
       v
SendMessageUseCase (Port)
       |
       v
SendMessageService (Implementation)
       |
       +---> ChatRoomRepository (채팅방 조회/검증)
       |
       +---> MessageRepository (메시지 저장)
       |
       +---> PrimaryKeyGenerator (Snowflake ID 생성)
```

## Test plan
- [ ] 빌드 성공 확인 (./gradlew build)
- [ ] UseCase 단위 테스트 (Spock)

Resolves #9