### PR TITLE
[TASK] 메시지 조회 UseCase 및 API 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/MessageController.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/MessageController.java
@@ -1,19 +1,25 @@
 package com.teambind.co.kr.chatdding.adapter.in.web.controller;
 
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.ApiResponse;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.GetMessagesResponse;
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.SendMessageRequest;
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.SendMessageResponse;
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesUseCase;
 import com.teambind.co.kr.chatdding.application.port.in.SendMessageResult;
 import com.teambind.co.kr.chatdding.application.port.in.SendMessageUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -25,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MessageController {
 
     private final SendMessageUseCase sendMessageUseCase;
+    private final GetMessagesUseCase getMessagesUseCase;
 
     /**
      * 메시지 전송
@@ -44,5 +51,24 @@ public class MessageController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(SendMessageResponse.from(result)));
+    }
+
+    /**
+     * 메시지 목록 조회 (커서 기반 페이징)
+     *
+     * GET /api/v1/rooms/{roomId}/messages
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<GetMessagesResponse>> getMessages(
+            @PathVariable String roomId,
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "50") Integer limit
+    ) {
+        GetMessagesResult result = getMessagesUseCase.execute(
+                GetMessagesQuery.of(roomId, userId, cursor, limit)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(GetMessagesResponse.from(result)));
     }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/GetMessagesResponse.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/GetMessagesResponse.java
@@ -1,0 +1,40 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 메시지 목록 조회 API 응답 DTO
+ */
+public record GetMessagesResponse(
+        List<MessageItem> messages,
+        String nextCursor,
+        boolean hasMore
+) {
+
+    public static GetMessagesResponse from(GetMessagesResult result) {
+        List<MessageItem> items = result.messages().stream()
+                .map(m -> new MessageItem(
+                        m.messageId(),
+                        m.roomId(),
+                        m.senderId(),
+                        m.content(),
+                        m.readCount(),
+                        m.createdAt()
+                ))
+                .toList();
+
+        return new GetMessagesResponse(items, result.nextCursor(), result.hasMore());
+    }
+
+    public record MessageItem(
+            String messageId,
+            String roomId,
+            Long senderId,
+            String content,
+            int readCount,
+            LocalDateTime createdAt
+    ) {}
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetMessagesQuery.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetMessagesQuery.java
@@ -1,0 +1,52 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import com.teambind.co.kr.chatdding.domain.message.MessageId;
+
+/**
+ * 메시지 조회 Query DTO
+ *
+ * @param roomId   채팅방 ID
+ * @param userId   요청자 ID (권한 검증용)
+ * @param cursorId 커서 메시지 ID (이 메시지 이전 것들을 조회, null이면 최신부터)
+ * @param limit    조회할 메시지 수
+ */
+public record GetMessagesQuery(
+        RoomId roomId,
+        UserId userId,
+        MessageId cursorId,
+        int limit
+) {
+
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT = 100;
+
+    public GetMessagesQuery {
+        if (roomId == null) {
+            throw new IllegalArgumentException("roomId cannot be null");
+        }
+        if (userId == null) {
+            throw new IllegalArgumentException("userId cannot be null");
+        }
+        if (limit <= 0) {
+            limit = DEFAULT_LIMIT;
+        }
+        if (limit > MAX_LIMIT) {
+            limit = MAX_LIMIT;
+        }
+    }
+
+    public static GetMessagesQuery of(String roomId, Long userId, String cursorId, Integer limit) {
+        return new GetMessagesQuery(
+                RoomId.fromString(roomId),
+                UserId.of(userId),
+                cursorId != null && !cursorId.isBlank() ? MessageId.fromString(cursorId) : null,
+                limit != null ? limit : DEFAULT_LIMIT
+        );
+    }
+
+    public boolean hasCursor() {
+        return cursorId != null;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetMessagesResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetMessagesResult.java
@@ -1,0 +1,49 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.message.Message;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 메시지 조회 결과 DTO
+ */
+public record GetMessagesResult(
+        List<MessageItem> messages,
+        String nextCursor,
+        boolean hasMore
+) {
+
+    public static GetMessagesResult of(List<Message> messages, int requestedLimit) {
+        List<MessageItem> items = messages.stream()
+                .map(MessageItem::from)
+                .toList();
+
+        boolean hasMore = messages.size() >= requestedLimit;
+        String nextCursor = hasMore && !messages.isEmpty()
+                ? messages.get(messages.size() - 1).getId().toStringValue()
+                : null;
+
+        return new GetMessagesResult(items, nextCursor, hasMore);
+    }
+
+    public record MessageItem(
+            String messageId,
+            String roomId,
+            Long senderId,
+            String content,
+            int readCount,
+            LocalDateTime createdAt
+    ) {
+        public static MessageItem from(Message message) {
+            return new MessageItem(
+                    message.getId().toStringValue(),
+                    message.getRoomId().toStringValue(),
+                    message.getSenderId().getValue(),
+                    message.getContent(),
+                    message.getReadCount(),
+                    message.getCreatedAt()
+            );
+        }
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetMessagesUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetMessagesUseCase.java
@@ -1,0 +1,19 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import java.util.List;
+
+/**
+ * 메시지 조회 UseCase Port (Application Layer)
+ *
+ * <p>커서 기반 페이징으로 메시지 목록 조회</p>
+ */
+public interface GetMessagesUseCase {
+
+    /**
+     * 메시지 목록 조회
+     *
+     * @param query 조회 쿼리
+     * @return 메시지 목록 결과
+     */
+    GetMessagesResult execute(GetMessagesQuery query);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetMessagesService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetMessagesService.java
@@ -1,0 +1,70 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesUseCase;
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import com.teambind.co.kr.chatdding.domain.message.Message;
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 메시지 조회 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetMessagesService implements GetMessagesUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
+
+    @Override
+    public GetMessagesResult execute(GetMessagesQuery query) {
+        validateAccess(query);
+
+        List<Message> messages = fetchMessages(query);
+        List<Message> visibleMessages = filterVisibleMessages(messages, query.userId());
+
+        return GetMessagesResult.of(visibleMessages, query.limit());
+    }
+
+    private void validateAccess(GetMessagesQuery query) {
+        ChatRoom chatRoom = chatRoomRepository.findById(query.roomId())
+                .orElseThrow(() -> ChatException.of(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoom.isParticipant(query.userId())) {
+            throw ChatException.of(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+
+    private List<Message> fetchMessages(GetMessagesQuery query) {
+        if (query.hasCursor()) {
+            return messageRepository.findByRoomIdBeforeCursor(
+                    query.roomId(),
+                    query.cursorId(),
+                    query.limit()
+            );
+        }
+
+        return messageRepository.findByRoomIdOrderByCreatedAtDesc(
+                query.roomId(),
+                query.limit(),
+                0
+        );
+    }
+
+    private List<Message> filterVisibleMessages(List<Message> messages, UserId userId) {
+        return messages.stream()
+                .filter(message -> message.isVisibleTo(userId))
+                .toList();
+    }
+}


### PR DESCRIPTION
## Summary
- 메시지 목록 조회 기능 구현 (커서 기반 페이징)
- 채팅방 참여자 검증 및 삭제된 메시지 필터링

## API Endpoint

```
GET /api/v1/rooms/{roomId}/messages?cursor={messageId}&limit={limit}
```

**Headers:**
- `X-User-Id`: 요청자 ID

**Query Parameters:**
- `cursor` (optional): 마지막 메시지 ID (이전 메시지들을 조회)
- `limit` (optional, default=50, max=100): 조회할 메시지 수

**Response:**
```json
{
  "success": true,
  "data": {
    "messages": [
      {
        "messageId": "123",
        "roomId": "456",
        "senderId": 1,
        "content": "메시지 내용",
        "readCount": 2,
        "createdAt": "2024-01-01T12:00:00"
      }
    ],
    "nextCursor": "122",
    "hasMore": true
  }
}
```

## Changes
| 파일 | 설명 |
|------|------|
| `GetMessagesUseCase.java` | 메시지 조회 포트 인터페이스 |
| `GetMessagesQuery.java` | 조회 쿼리 DTO |
| `GetMessagesResult.java` | 조회 결과 DTO |
| `GetMessagesService.java` | UseCase 구현체 |
| `GetMessagesResponse.java` | API 응답 DTO |
| `MessageController.java` | GET 엔드포인트 추가 |

## Test plan
- [ ] 빌드 성공 확인 (./gradlew build)
- [ ] API 통합 테스트

Resolves #11