### PR TITLE
[TASK] 채팅방 목록 조회 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/ChatRoomController.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/ChatRoomController.java
@@ -1,0 +1,40 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.controller;
+
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.ApiResponse;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.GetChatRoomsResponse;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 채팅방 API Controller (Web Adapter)
+ */
+@RestController
+@RequestMapping("/api/v1/rooms")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final GetChatRoomsUseCase getChatRoomsUseCase;
+
+    /**
+     * 채팅방 목록 조회
+     *
+     * GET /api/v1/rooms
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<GetChatRoomsResponse>> getChatRooms(
+            @RequestHeader("X-User-Id") Long userId
+    ) {
+        GetChatRoomsResult result = getChatRoomsUseCase.execute(
+                GetChatRoomsQuery.of(userId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(GetChatRoomsResponse.from(result)));
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/GetChatRoomsResponse.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/GetChatRoomsResponse.java
@@ -1,0 +1,41 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsResult;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 채팅방 목록 조회 API 응답 DTO
+ */
+public record GetChatRoomsResponse(
+        List<ChatRoomItem> chatRooms
+) {
+
+    public static GetChatRoomsResponse from(GetChatRoomsResult result) {
+        List<ChatRoomItem> items = result.chatRooms().stream()
+                .map(r -> new ChatRoomItem(
+                        r.roomId(),
+                        r.type(),
+                        r.name(),
+                        r.participantIds(),
+                        r.lastMessage(),
+                        r.lastMessageAt(),
+                        r.unreadCount()
+                ))
+                .toList();
+
+        return new GetChatRoomsResponse(items);
+    }
+
+    public record ChatRoomItem(
+            String roomId,
+            ChatRoomType type,
+            String name,
+            List<Long> participantIds,
+            String lastMessage,
+            LocalDateTime lastMessageAt,
+            long unreadCount
+    ) {}
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomsQuery.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomsQuery.java
@@ -1,0 +1,23 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+/**
+ * 채팅방 목록 조회 Query DTO
+ *
+ * @param userId 요청자 ID
+ */
+public record GetChatRoomsQuery(
+        UserId userId
+) {
+
+    public GetChatRoomsQuery {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId cannot be null");
+        }
+    }
+
+    public static GetChatRoomsQuery of(Long userId) {
+        return new GetChatRoomsQuery(UserId.of(userId));
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomsResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomsResult.java
@@ -1,0 +1,42 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType;
+import com.teambind.co.kr.chatdding.domain.message.Message;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 채팅방 목록 조회 결과 DTO
+ */
+public record GetChatRoomsResult(
+        List<ChatRoomItem> chatRooms
+) {
+
+    public record ChatRoomItem(
+            String roomId,
+            ChatRoomType type,
+            String name,
+            List<Long> participantIds,
+            String lastMessage,
+            LocalDateTime lastMessageAt,
+            long unreadCount
+    ) {
+        public static ChatRoomItem from(ChatRoom chatRoom, Message lastMessage, long unreadCount) {
+            List<Long> participantIds = chatRoom.getParticipantIds().stream()
+                    .map(id -> id.getValue())
+                    .toList();
+
+            return new ChatRoomItem(
+                    chatRoom.getId().toStringValue(),
+                    chatRoom.getType(),
+                    chatRoom.getName(),
+                    participantIds,
+                    lastMessage != null ? lastMessage.getContentPreview() : null,
+                    chatRoom.getLastMessageAt(),
+                    unreadCount
+            );
+        }
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomsUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomsUseCase.java
@@ -1,0 +1,15 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+/**
+ * 채팅방 목록 조회 UseCase Port
+ */
+public interface GetChatRoomsUseCase {
+
+    /**
+     * 사용자의 채팅방 목록 조회
+     *
+     * @param query 조회 쿼리
+     * @return 채팅방 목록 결과
+     */
+    GetChatRoomsResult execute(GetChatRoomsQuery query);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetChatRoomsService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetChatRoomsService.java
@@ -1,0 +1,50 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsUseCase;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.message.Message;
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 채팅방 목록 조회 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetChatRoomsService implements GetChatRoomsUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
+
+    @Override
+    public GetChatRoomsResult execute(GetChatRoomsQuery query) {
+        List<ChatRoom> chatRooms = chatRoomRepository
+                .findActiveByParticipantUserIdOrderByLastMessageAtDesc(query.userId());
+
+        List<GetChatRoomsResult.ChatRoomItem> items = chatRooms.stream()
+                .map(chatRoom -> buildChatRoomItem(chatRoom, query))
+                .toList();
+
+        return new GetChatRoomsResult(items);
+    }
+
+    private GetChatRoomsResult.ChatRoomItem buildChatRoomItem(ChatRoom chatRoom, GetChatRoomsQuery query) {
+        Message lastMessage = messageRepository.findLatestByRoomId(chatRoom.getId())
+                .orElse(null);
+
+        long unreadCount = messageRepository.countUnreadByRoomIdAndUserId(
+                chatRoom.getId(),
+                query.userId()
+        );
+
+        return GetChatRoomsResult.ChatRoomItem.from(chatRoom, lastMessage, unreadCount);
+    }
+}


### PR DESCRIPTION
## Summary
- 사용자의 채팅방 목록 조회 기능 구현
- 마지막 메시지 미리보기 및 읽지 않은 메시지 수 포함

## API Endpoint

```
GET /api/v1/rooms
```

**Headers:**
- `X-User-Id`: 요청자 ID

**Response:**
```json
{
  "success": true,
  "data": {
    "chatRooms": [
      {
        "roomId": "123",
        "type": "DM",
        "name": null,
        "participantIds": [1, 2],
        "lastMessage": "안녕하세요...",
        "lastMessageAt": "2024-01-01T12:00:00",
        "unreadCount": 5
      }
    ]
  }
}
```

## Changes
| 파일 | 설명 |
|------|------|
| `GetChatRoomsUseCase.java` | 포트 인터페이스 |
| `GetChatRoomsQuery.java` | 쿼리 DTO |
| `GetChatRoomsResult.java` | 결과 DTO |
| `GetChatRoomsService.java` | UseCase 구현체 |
| `ChatRoomController.java` | REST 컨트롤러 |
| `GetChatRoomsResponse.java` | API 응답 DTO |

## Test plan
- [ ] 빌드 성공 확인

Resolves #12