### PR TITLE
[TASK] 채팅방 상세 조회 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/ChatRoomController.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/ChatRoomController.java
@@ -1,13 +1,18 @@
 package com.teambind.co.kr.chatdding.adapter.in.web.controller;
 
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.ApiResponse;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.GetChatRoomDetailResponse;
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.GetChatRoomsResponse;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailUseCase;
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsQuery;
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsResult;
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController {
 
     private final GetChatRoomsUseCase getChatRoomsUseCase;
+    private final GetChatRoomDetailUseCase getChatRoomDetailUseCase;
 
     /**
      * 채팅방 목록 조회
@@ -36,5 +42,22 @@ public class ChatRoomController {
         );
 
         return ResponseEntity.ok(ApiResponse.success(GetChatRoomsResponse.from(result)));
+    }
+
+    /**
+     * 채팅방 상세 조회
+     *
+     * GET /api/v1/rooms/{roomId}
+     */
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse<GetChatRoomDetailResponse>> getChatRoomDetail(
+            @PathVariable String roomId,
+            @RequestHeader("X-User-Id") Long userId
+    ) {
+        GetChatRoomDetailResult result = getChatRoomDetailUseCase.execute(
+                GetChatRoomDetailQuery.of(roomId, userId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(GetChatRoomDetailResponse.from(result)));
     }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/GetChatRoomDetailResponse.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/GetChatRoomDetailResponse.java
@@ -1,0 +1,54 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailResult;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomStatus;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 채팅방 상세 조회 API 응답 DTO
+ */
+public record GetChatRoomDetailResponse(
+        String roomId,
+        ChatRoomType type,
+        String name,
+        List<ParticipantInfo> participants,
+        Long ownerId,
+        ChatRoomStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime lastMessageAt,
+        long unreadCount
+) {
+
+    public static GetChatRoomDetailResponse from(GetChatRoomDetailResult result) {
+        List<ParticipantInfo> participants = result.participants().stream()
+                .map(p -> new ParticipantInfo(
+                        p.userId(),
+                        p.notificationEnabled(),
+                        p.lastReadAt(),
+                        p.joinedAt()
+                ))
+                .toList();
+
+        return new GetChatRoomDetailResponse(
+                result.roomId(),
+                result.type(),
+                result.name(),
+                participants,
+                result.ownerId(),
+                result.status(),
+                result.createdAt(),
+                result.lastMessageAt(),
+                result.unreadCount()
+        );
+    }
+
+    public record ParticipantInfo(
+            Long userId,
+            boolean notificationEnabled,
+            LocalDateTime lastReadAt,
+            LocalDateTime joinedAt
+    ) {}
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomDetailQuery.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomDetailQuery.java
@@ -1,0 +1,32 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+/**
+ * 채팅방 상세 조회 Query DTO
+ *
+ * @param roomId 채팅방 ID
+ * @param userId 요청자 ID (권한 검증용)
+ */
+public record GetChatRoomDetailQuery(
+        RoomId roomId,
+        UserId userId
+) {
+
+    public GetChatRoomDetailQuery {
+        if (roomId == null) {
+            throw new IllegalArgumentException("roomId cannot be null");
+        }
+        if (userId == null) {
+            throw new IllegalArgumentException("userId cannot be null");
+        }
+    }
+
+    public static GetChatRoomDetailQuery of(String roomId, Long userId) {
+        return new GetChatRoomDetailQuery(
+                RoomId.fromString(roomId),
+                UserId.of(userId)
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomDetailResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomDetailResult.java
@@ -1,0 +1,59 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomStatus;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType;
+import com.teambind.co.kr.chatdding.domain.chatroom.Participant;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 채팅방 상세 조회 결과 DTO
+ */
+public record GetChatRoomDetailResult(
+        String roomId,
+        ChatRoomType type,
+        String name,
+        List<ParticipantInfo> participants,
+        Long ownerId,
+        ChatRoomStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime lastMessageAt,
+        long unreadCount
+) {
+
+    public static GetChatRoomDetailResult from(ChatRoom chatRoom, long unreadCount) {
+        List<ParticipantInfo> participantInfos = chatRoom.getParticipants().stream()
+                .map(ParticipantInfo::from)
+                .toList();
+
+        return new GetChatRoomDetailResult(
+                chatRoom.getId().toStringValue(),
+                chatRoom.getType(),
+                chatRoom.getName(),
+                participantInfos,
+                chatRoom.getOwnerId().getValue(),
+                chatRoom.getStatus(),
+                chatRoom.getCreatedAt(),
+                chatRoom.getLastMessageAt(),
+                unreadCount
+        );
+    }
+
+    public record ParticipantInfo(
+            Long userId,
+            boolean notificationEnabled,
+            LocalDateTime lastReadAt,
+            LocalDateTime joinedAt
+    ) {
+        public static ParticipantInfo from(Participant participant) {
+            return new ParticipantInfo(
+                    participant.getUserId().getValue(),
+                    participant.isNotificationEnabled(),
+                    participant.getLastReadAt(),
+                    participant.getJoinedAt()
+            );
+        }
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomDetailUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetChatRoomDetailUseCase.java
@@ -1,0 +1,15 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+/**
+ * 채팅방 상세 조회 UseCase Port
+ */
+public interface GetChatRoomDetailUseCase {
+
+    /**
+     * 채팅방 상세 정보 조회
+     *
+     * @param query 조회 쿼리
+     * @return 채팅방 상세 결과
+     */
+    GetChatRoomDetailResult execute(GetChatRoomDetailQuery query);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetChatRoomDetailService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetChatRoomDetailService.java
@@ -1,0 +1,46 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailUseCase;
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 채팅방 상세 조회 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetChatRoomDetailService implements GetChatRoomDetailUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
+
+    @Override
+    public GetChatRoomDetailResult execute(GetChatRoomDetailQuery query) {
+        ChatRoom chatRoom = chatRoomRepository.findById(query.roomId())
+                .orElseThrow(() -> ChatException.of(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        validateAccess(chatRoom, query);
+
+        long unreadCount = messageRepository.countUnreadByRoomIdAndUserId(
+                query.roomId(),
+                query.userId()
+        );
+
+        return GetChatRoomDetailResult.from(chatRoom, unreadCount);
+    }
+
+    private void validateAccess(ChatRoom chatRoom, GetChatRoomDetailQuery query) {
+        if (!chatRoom.isParticipant(query.userId())) {
+            throw ChatException.of(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 채팅방 상세 정보 조회 기능 구현
- 참여자 상세 정보 및 읽지 않은 메시지 수 포함

## API Endpoint

```
GET /api/v1/rooms/{roomId}
```

**Headers:**
- `X-User-Id`: 요청자 ID

**Response:**
```json
{
  "success": true,
  "data": {
    "roomId": "123",
    "type": "GROUP",
    "name": "팀 채팅방",
    "participants": [
      {
        "userId": 1,
        "notificationEnabled": true,
        "lastReadAt": "2024-01-01T12:00:00",
        "joinedAt": "2024-01-01T10:00:00"
      }
    ],
    "ownerId": 1,
    "status": "ACTIVE",
    "createdAt": "2024-01-01T10:00:00",
    "lastMessageAt": "2024-01-01T12:00:00",
    "unreadCount": 5
  }
}
```

## Changes
| 파일 | 설명 |
|------|------|
| `GetChatRoomDetailUseCase.java` | 포트 인터페이스 |
| `GetChatRoomDetailQuery.java` | 쿼리 DTO |
| `GetChatRoomDetailResult.java` | 결과 DTO |
| `GetChatRoomDetailService.java` | UseCase 구현체 |
| `ChatRoomController.java` | 상세 조회 API 추가 |
| `GetChatRoomDetailResponse.java` | API 응답 DTO |

## Test plan
- [ ] 빌드 성공 확인

Resolves #13