### PR TITLE
[TASK] 읽음 처리 UseCase 및 API 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/MessageController.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/MessageController.java
@@ -2,11 +2,16 @@ package com.teambind.co.kr.chatdding.adapter.in.web.controller;
 
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.ApiResponse;
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.GetMessagesResponse;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.MarkAsReadRequest;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.MarkAsReadResponse;
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.SendMessageRequest;
 import com.teambind.co.kr.chatdding.adapter.in.web.dto.SendMessageResponse;
 import com.teambind.co.kr.chatdding.application.port.in.GetMessagesQuery;
 import com.teambind.co.kr.chatdding.application.port.in.GetMessagesResult;
 import com.teambind.co.kr.chatdding.application.port.in.GetMessagesUseCase;
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadCommand;
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadResult;
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadUseCase;
 import com.teambind.co.kr.chatdding.application.port.in.SendMessageResult;
 import com.teambind.co.kr.chatdding.application.port.in.SendMessageUseCase;
 import jakarta.validation.Valid;
@@ -32,6 +37,7 @@ public class MessageController {
 
     private final SendMessageUseCase sendMessageUseCase;
     private final GetMessagesUseCase getMessagesUseCase;
+    private final MarkAsReadUseCase markAsReadUseCase;
 
     /**
      * 메시지 전송
@@ -70,5 +76,25 @@ public class MessageController {
         );
 
         return ResponseEntity.ok(ApiResponse.success(GetMessagesResponse.from(result)));
+    }
+
+    /**
+     * 읽음 처리
+     *
+     * POST /api/v1/rooms/{roomId}/messages/read
+     */
+    @PostMapping("/read")
+    public ResponseEntity<ApiResponse<MarkAsReadResponse>> markAsRead(
+            @PathVariable String roomId,
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody(required = false) MarkAsReadRequest request
+    ) {
+        MarkAsReadResult result = markAsReadUseCase.execute(
+                request != null
+                        ? request.toCommand(roomId, userId)
+                        : MarkAsReadCommand.of(roomId, userId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(MarkAsReadResponse.from(result)));
     }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/MarkAsReadRequest.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/MarkAsReadRequest.java
@@ -1,0 +1,15 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto;
+
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadCommand;
+
+/**
+ * 읽음 처리 API 요청 DTO
+ */
+public record MarkAsReadRequest(
+        String lastMessageId
+) {
+
+    public MarkAsReadCommand toCommand(String roomId, Long userId) {
+        return MarkAsReadCommand.of(roomId, userId, lastMessageId);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/MarkAsReadResponse.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/MarkAsReadResponse.java
@@ -1,0 +1,25 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto;
+
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadResult;
+
+import java.time.LocalDateTime;
+
+/**
+ * 읽음 처리 API 응답 DTO
+ */
+public record MarkAsReadResponse(
+        String roomId,
+        Long userId,
+        LocalDateTime readAt,
+        int readCount
+) {
+
+    public static MarkAsReadResponse from(MarkAsReadResult result) {
+        return new MarkAsReadResponse(
+                result.roomId(),
+                result.userId(),
+                result.readAt(),
+                result.readCount()
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/MarkAsReadCommand.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/MarkAsReadCommand.java
@@ -1,0 +1,42 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import com.teambind.co.kr.chatdding.domain.message.MessageId;
+
+/**
+ * 읽음 처리 Command DTO
+ *
+ * @param roomId        채팅방 ID
+ * @param userId        요청자 ID
+ * @param lastMessageId 마지막으로 읽은 메시지 ID (optional, null이면 모든 메시지 읽음 처리)
+ */
+public record MarkAsReadCommand(
+        RoomId roomId,
+        UserId userId,
+        MessageId lastMessageId
+) {
+
+    public MarkAsReadCommand {
+        if (roomId == null) {
+            throw new IllegalArgumentException("roomId cannot be null");
+        }
+        if (userId == null) {
+            throw new IllegalArgumentException("userId cannot be null");
+        }
+    }
+
+    public static MarkAsReadCommand of(String roomId, Long userId, String lastMessageId) {
+        return new MarkAsReadCommand(
+                RoomId.fromString(roomId),
+                UserId.of(userId),
+                lastMessageId != null && !lastMessageId.isBlank()
+                        ? MessageId.fromString(lastMessageId)
+                        : null
+        );
+    }
+
+    public static MarkAsReadCommand of(String roomId, Long userId) {
+        return of(roomId, userId, null);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/MarkAsReadResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/MarkAsReadResult.java
@@ -1,0 +1,23 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import java.time.LocalDateTime;
+
+/**
+ * 읽음 처리 결과 DTO
+ *
+ * @param roomId       채팅방 ID
+ * @param userId       사용자 ID
+ * @param readAt       읽음 처리 시간
+ * @param readCount    읽음 처리된 메시지 수
+ */
+public record MarkAsReadResult(
+        String roomId,
+        Long userId,
+        LocalDateTime readAt,
+        int readCount
+) {
+
+    public static MarkAsReadResult of(String roomId, Long userId, LocalDateTime readAt, int readCount) {
+        return new MarkAsReadResult(roomId, userId, readAt, readCount);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/MarkAsReadUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/MarkAsReadUseCase.java
@@ -1,0 +1,15 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+/**
+ * 읽음 처리 UseCase Port
+ */
+public interface MarkAsReadUseCase {
+
+    /**
+     * 채팅방 메시지 읽음 처리
+     *
+     * @param command 읽음 처리 명령
+     * @return 읽음 처리 결과
+     */
+    MarkAsReadResult execute(MarkAsReadCommand command);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/MarkAsReadService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/MarkAsReadService.java
@@ -1,0 +1,97 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadCommand;
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadResult;
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadUseCase;
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.chatroom.Participant;
+import com.teambind.co.kr.chatdding.domain.message.Message;
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 읽음 처리 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MarkAsReadService implements MarkAsReadUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
+
+    @Override
+    public MarkAsReadResult execute(MarkAsReadCommand command) {
+        ChatRoom chatRoom = validateAndGetChatRoom(command);
+        LocalDateTime readAt = LocalDateTime.now();
+
+        List<Message> unreadMessages = getUnreadMessages(command);
+        int readCount = markMessagesAsRead(unreadMessages, command, readAt);
+
+        updateParticipantLastReadAt(chatRoom, command, readAt);
+
+        return MarkAsReadResult.of(
+                command.roomId().toStringValue(),
+                command.userId().getValue(),
+                readAt,
+                readCount
+        );
+    }
+
+    private ChatRoom validateAndGetChatRoom(MarkAsReadCommand command) {
+        ChatRoom chatRoom = chatRoomRepository.findById(command.roomId())
+                .orElseThrow(() -> ChatException.of(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoom.isParticipant(command.userId())) {
+            throw ChatException.of(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+
+        return chatRoom;
+    }
+
+    private List<Message> getUnreadMessages(MarkAsReadCommand command) {
+        if (command.lastMessageId() != null) {
+            Message lastMessage = messageRepository.findById(command.lastMessageId())
+                    .orElseThrow(() -> ChatException.of(ErrorCode.MESSAGE_NOT_FOUND));
+
+            return messageRepository.findByRoomIdAndCreatedAtAfter(
+                    command.roomId(),
+                    lastMessage.getCreatedAt().minusSeconds(1)
+            );
+        }
+
+        return messageRepository.findByRoomIdOrderByCreatedAtDesc(
+                command.roomId(),
+                100,
+                0
+        );
+    }
+
+    private int markMessagesAsRead(List<Message> messages, MarkAsReadCommand command, LocalDateTime readAt) {
+        int count = 0;
+        for (Message message : messages) {
+            if (!message.isReadBy(command.userId())) {
+                message.markAsReadAt(command.userId(), readAt);
+                messageRepository.save(message);
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private void updateParticipantLastReadAt(ChatRoom chatRoom, MarkAsReadCommand command, LocalDateTime readAt) {
+        chatRoom.findParticipant(command.userId())
+                .ifPresent(participant -> {
+                    participant.updateLastReadAt(readAt);
+                    chatRoomRepository.save(chatRoom);
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- 메시지 읽음 처리 기능 구현
- 채팅방 내 메시지를 읽음 상태로 변경

## API Endpoint

```
POST /api/v1/rooms/{roomId}/messages/read
```

**Headers:**
- `X-User-Id`: 요청자 ID

**Request Body (optional):**
```json
{
  "lastMessageId": "123456789"
}
```
- `lastMessageId`: 마지막으로 읽은 메시지 ID (생략 시 모든 메시지 읽음 처리)

**Response:**
```json
{
  "success": true,
  "data": {
    "roomId": "123",
    "userId": 1,
    "readAt": "2024-01-01T12:00:00",
    "readCount": 10
  }
}
```

## Changes
| 파일 | 설명 |
|------|------|
| `MarkAsReadUseCase.java` | 포트 인터페이스 |
| `MarkAsReadCommand.java` | 명령 DTO |
| `MarkAsReadResult.java` | 결과 DTO |
| `MarkAsReadService.java` | UseCase 구현체 |
| `MessageController.java` | 읽음 처리 API 추가 |
| `MarkAsReadRequest.java` | API 요청 DTO |
| `MarkAsReadResponse.java` | API 응답 DTO |

## Test plan
- [ ] 빌드 성공 확인

Resolves #14