### PR TITLE
[TASK] Kafka Producer 및 이벤트 발행 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/out/EventPublisher.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/out/EventPublisher.java
@@ -1,0 +1,27 @@
+package com.teambind.co.kr.chatdding.application.port.out;
+
+import com.teambind.co.kr.chatdding.domain.event.ChatEvent;
+
+/**
+ * 이벤트 발행 Port (Outbound)
+ *
+ * <p>Hexagonal Architecture의 Outbound Port</p>
+ * <p>도메인 이벤트를 외부 메시징 시스템으로 발행</p>
+ */
+public interface EventPublisher {
+
+    /**
+     * 이벤트 발행
+     *
+     * @param event 발행할 이벤트
+     */
+    void publish(ChatEvent event);
+
+    /**
+     * 특정 토픽으로 이벤트 발행
+     *
+     * @param topic 토픽명
+     * @param event 발행할 이벤트
+     */
+    void publish(String topic, ChatEvent event);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/ChatEvent.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/ChatEvent.java
@@ -1,0 +1,13 @@
+package com.teambind.co.kr.chatdding.domain.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 채팅 도메인 이벤트 기본 인터페이스
+ */
+public interface ChatEvent {
+
+    String getEventType();
+
+    LocalDateTime getOccurredAt();
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/MessageReadEvent.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/MessageReadEvent.java
@@ -1,0 +1,35 @@
+package com.teambind.co.kr.chatdding.domain.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 메시지 읽음 이벤트
+ */
+public record MessageReadEvent(
+        String roomId,
+        Long userId,
+        int readCount,
+        LocalDateTime occurredAt
+) implements ChatEvent {
+
+    public static final String EVENT_TYPE = "MESSAGE_READ";
+
+    public static MessageReadEvent of(String roomId, Long userId, int readCount) {
+        return new MessageReadEvent(
+                roomId,
+                userId,
+                readCount,
+                LocalDateTime.now()
+        );
+    }
+
+    @Override
+    public String getEventType() {
+        return EVENT_TYPE;
+    }
+
+    @Override
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/MessageSentEvent.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/MessageSentEvent.java
@@ -1,0 +1,44 @@
+package com.teambind.co.kr.chatdding.domain.event;
+
+import com.teambind.co.kr.chatdding.domain.message.Message;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 메시지 전송 이벤트
+ */
+public record MessageSentEvent(
+        String messageId,
+        String roomId,
+        Long senderId,
+        String content,
+        String contentPreview,
+        List<Long> recipientIds,
+        LocalDateTime occurredAt
+) implements ChatEvent {
+
+    public static final String EVENT_TYPE = "MESSAGE_SENT";
+
+    public static MessageSentEvent from(Message message, List<Long> recipientIds) {
+        return new MessageSentEvent(
+                message.getId().toStringValue(),
+                message.getRoomId().toStringValue(),
+                message.getSenderId().getValue(),
+                message.getContent(),
+                message.getContentPreview(),
+                recipientIds,
+                message.getCreatedAt()
+        );
+    }
+
+    @Override
+    public String getEventType() {
+        return EVENT_TYPE;
+    }
+
+    @Override
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/messaging/kafka/KafkaEventPublisher.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/messaging/kafka/KafkaEventPublisher.java
@@ -1,0 +1,71 @@
+package com.teambind.co.kr.chatdding.infrastructure.messaging.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teambind.co.kr.chatdding.application.port.out.EventPublisher;
+import com.teambind.co.kr.chatdding.domain.event.ChatEvent;
+import com.teambind.co.kr.chatdding.domain.event.MessageReadEvent;
+import com.teambind.co.kr.chatdding.domain.event.MessageSentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka 이벤트 발행 Adapter
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaEventPublisher implements EventPublisher {
+
+    private static final String TOPIC_MESSAGE_SENT = "chat-message-sent";
+    private static final String TOPIC_MESSAGE_READ = "chat-message-read";
+    private static final String TOPIC_DEFAULT = "chat-events";
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void publish(ChatEvent event) {
+        String topic = resolveTopicFor(event);
+        publish(topic, event);
+    }
+
+    @Override
+    public void publish(String topic, ChatEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            String key = extractKeyFrom(event);
+
+            kafkaTemplate.send(topic, key, payload)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            log.error("Failed to publish event to topic {}: {}", topic, event.getEventType(), ex);
+                        } else {
+                            log.debug("Event published to topic {}: {} with key {}",
+                                    topic, event.getEventType(), key);
+                        }
+                    });
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize event: {}", event.getEventType(), e);
+        }
+    }
+
+    private String resolveTopicFor(ChatEvent event) {
+        return switch (event) {
+            case MessageSentEvent ignored -> TOPIC_MESSAGE_SENT;
+            case MessageReadEvent ignored -> TOPIC_MESSAGE_READ;
+            default -> TOPIC_DEFAULT;
+        };
+    }
+
+    private String extractKeyFrom(ChatEvent event) {
+        return switch (event) {
+            case MessageSentEvent e -> e.roomId();
+            case MessageReadEvent e -> e.roomId();
+            default -> null;
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- 도메인 이벤트 정의 및 Kafka Producer를 통한 이벤트 발행 구현
- 메시지 전송 시 자동으로 이벤트 발행

## Architecture
```
Application Layer
  SendMessageService
       |
       v
  EventPublisher (Port)
       |
       v
Infrastructure Layer
  KafkaEventPublisher --> Kafka Broker
```

## Kafka Topics
| Topic | Event | 설명 |
|-------|-------|------|
| `chat-message-sent` | MessageSentEvent | 메시지 전송 시 발행 |
| `chat-message-read` | MessageReadEvent | 읽음 처리 시 발행 |

## Event Payload Examples

**MessageSentEvent:**
```json
{
  "messageId": "123",
  "roomId": "456",
  "senderId": 1,
  "content": "Hello",
  "contentPreview": "Hello",
  "recipientIds": [2, 3],
  "occurredAt": "2024-01-01T12:00:00"
}
```

## Changes
| 파일 | 설명 |
|------|------|
| `ChatEvent.java` | 도메인 이벤트 인터페이스 |
| `MessageSentEvent.java` | 메시지 전송 이벤트 |
| `MessageReadEvent.java` | 읽음 처리 이벤트 |
| `EventPublisher.java` | 아웃바운드 포트 |
| `KafkaEventPublisher.java` | Kafka 어댑터 |
| `SendMessageService.java` | 이벤트 발행 추가 |

## Test plan
- [ ] 빌드 성공 확인
- [ ] Docker Compose로 Kafka 실행 후 통합 테스트

Resolves #15