### PR TITLE
Story #29: Web Adapter 테스트 작성

### DIFF
--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/GlobalExceptionHandlerSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/GlobalExceptionHandlerSpec.groovy
@@ -1,0 +1,211 @@
+package com.teambind.co.kr.chatdding.adapter.in.web
+
+import com.teambind.co.kr.chatdding.common.exception.ChatException
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class GlobalExceptionHandlerSpec extends Specification {
+
+    @Subject
+    GlobalExceptionHandler exceptionHandler = new GlobalExceptionHandler()
+
+    MockMvc mockMvc
+
+    def setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestController())
+                .setControllerAdvice(exceptionHandler)
+                .build()
+    }
+
+    def "ChatException 처리 - CHAT_ROOM_NOT_FOUND"() {
+        when:
+        def response = mockMvc.perform(get("/test/chat-exception/not-found"))
+
+        then:
+        response.andExpect(status().isNotFound())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_001"))
+                .andExpect(jsonPath('$.error.message').exists())
+    }
+
+    def "ChatException 처리 - CHAT_ROOM_ACCESS_DENIED"() {
+        when:
+        def response = mockMvc.perform(get("/test/chat-exception/access-denied"))
+
+        then:
+        response.andExpect(status().isForbidden())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_002"))
+    }
+
+    def "ChatException 처리 - MESSAGE_NOT_FOUND"() {
+        when:
+        def response = mockMvc.perform(get("/test/chat-exception/message-not-found"))
+
+        then:
+        response.andExpect(status().isNotFound())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_006"))
+    }
+
+    def "ChatException 처리 - MESSAGE_CONTENT_EMPTY"() {
+        when:
+        def response = mockMvc.perform(get("/test/chat-exception/content-empty"))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_004"))
+    }
+
+    def "MethodArgumentNotValidException 처리"() {
+        when:
+        def response = mockMvc.perform(post("/test/validation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"name": ""}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("VALIDATION_ERROR"))
+                .andExpect(jsonPath('$.error.message').exists())
+    }
+
+    def "MissingRequestHeaderException 처리"() {
+        when:
+        def response = mockMvc.perform(get("/test/missing-header"))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("MISSING_HEADER"))
+                .andExpect(jsonPath('$.error.message').value("필수 헤더가 누락되었습니다: X-User-Id"))
+    }
+
+    def "IllegalArgumentException 처리"() {
+        when:
+        def response = mockMvc.perform(get("/test/illegal-argument"))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("BAD_REQUEST"))
+                .andExpect(jsonPath('$.error.message').value("잘못된 인자입니다"))
+    }
+
+    def "일반 Exception 처리"() {
+        when:
+        def response = mockMvc.perform(get("/test/unexpected-error"))
+
+        then:
+        response.andExpect(status().isInternalServerError())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("INTERNAL_ERROR"))
+                .andExpect(jsonPath('$.error.message').value("서버 내부 오류가 발생했습니다"))
+    }
+
+    def "ChatException 직접 호출 테스트"() {
+        given:
+        def exception = new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND)
+
+        when:
+        def result = exceptionHandler.handleChatException(exception)
+
+        then:
+        result.statusCode.value() == 404
+        result.body.success() == false
+        result.body.error().code() == "CHAT_001"
+    }
+
+    def "IllegalArgumentException 직접 호출 테스트"() {
+        given:
+        def exception = new IllegalArgumentException("테스트 오류")
+
+        when:
+        def result = exceptionHandler.handleIllegalArgumentException(exception)
+
+        then:
+        result.statusCode.value() == 400
+        result.body.success() == false
+        result.body.error().code() == "BAD_REQUEST"
+        result.body.error().message() == "테스트 오류"
+    }
+
+    def "일반 Exception 직접 호출 테스트"() {
+        given:
+        def exception = new RuntimeException("예상치 못한 오류")
+
+        when:
+        def result = exceptionHandler.handleException(exception)
+
+        then:
+        result.statusCode.value() == 500
+        result.body.success() == false
+        result.body.error().code() == "INTERNAL_ERROR"
+    }
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/test/chat-exception/not-found")
+        void chatRoomNotFound() {
+            throw new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND)
+        }
+
+        @GetMapping("/test/chat-exception/access-denied")
+        void accessDenied() {
+            throw new ChatException(ErrorCode.CHAT_ROOM_ACCESS_DENIED)
+        }
+
+        @GetMapping("/test/chat-exception/message-not-found")
+        void messageNotFound() {
+            throw new ChatException(ErrorCode.MESSAGE_NOT_FOUND)
+        }
+
+        @GetMapping("/test/chat-exception/content-empty")
+        void contentEmpty() {
+            throw new ChatException(ErrorCode.MESSAGE_CONTENT_EMPTY)
+        }
+
+        @PostMapping("/test/validation")
+        void validation(@Valid @RequestBody TestRequest request) {
+            // validation test
+        }
+
+        @GetMapping("/test/missing-header")
+        void missingHeader(@RequestHeader("X-User-Id") Long userId) {
+            // missing header test
+        }
+
+        @GetMapping("/test/illegal-argument")
+        void illegalArgument() {
+            throw new IllegalArgumentException("잘못된 인자입니다")
+        }
+
+        @GetMapping("/test/unexpected-error")
+        void unexpectedError() {
+            throw new RuntimeException("예상치 못한 오류")
+        }
+
+        static class TestRequest {
+            @NotBlank(message = "이름은 필수입니다")
+            String name
+        }
+    }
+}

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/controller/ChatRoomControllerSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/controller/ChatRoomControllerSpec.groovy
@@ -1,0 +1,261 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.controller
+
+import com.teambind.co.kr.chatdding.adapter.in.web.GlobalExceptionHandler
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailResult
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomDetailUseCase
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsResult
+import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsUseCase
+import com.teambind.co.kr.chatdding.common.exception.ChatException
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomStatus
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDateTime
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class ChatRoomControllerSpec extends Specification {
+
+    GetChatRoomsUseCase getChatRoomsUseCase = Mock()
+    GetChatRoomDetailUseCase getChatRoomDetailUseCase = Mock()
+
+    @Subject
+    ChatRoomController chatRoomController
+
+    MockMvc mockMvc
+
+    def setup() {
+        chatRoomController = new ChatRoomController(getChatRoomsUseCase, getChatRoomDetailUseCase)
+        mockMvc = MockMvcBuilders.standaloneSetup(chatRoomController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build()
+    }
+
+    def "채팅방 목록 조회 성공"() {
+        given:
+        def userId = 100L
+        def chatRooms = [
+                new GetChatRoomsResult.ChatRoomItem(
+                        "1001",
+                        ChatRoomType.DM,
+                        "User2",
+                        [100L, 200L],
+                        "마지막 메시지",
+                        LocalDateTime.now(),
+                        3
+                ),
+                new GetChatRoomsResult.ChatRoomItem(
+                        "1002",
+                        ChatRoomType.GROUP,
+                        "개발팀",
+                        [100L, 200L, 300L],
+                        "안녕하세요",
+                        LocalDateTime.now(),
+                        0
+                )
+        ]
+        def result = new GetChatRoomsResult(chatRooms)
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms")
+                .header("X-User-Id", userId))
+
+        then:
+        1 * getChatRoomsUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.chatRooms').isArray())
+                .andExpect(jsonPath('$.data.chatRooms.length()').value(2))
+                .andExpect(jsonPath('$.data.chatRooms[0].roomId').value("1001"))
+                .andExpect(jsonPath('$.data.chatRooms[0].type').value("DM"))
+                .andExpect(jsonPath('$.data.chatRooms[0].unreadCount').value(3))
+    }
+
+    def "채팅방 목록이 비어있는 경우"() {
+        given:
+        def userId = 100L
+        def result = new GetChatRoomsResult([])
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms")
+                .header("X-User-Id", userId))
+
+        then:
+        1 * getChatRoomsUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.data.chatRooms').isEmpty())
+    }
+
+    def "채팅방 목록 조회 시 X-User-Id 헤더 누락"() {
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms"))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("MISSING_HEADER"))
+    }
+
+    def "채팅방 상세 조회 성공"() {
+        given:
+        def roomId = "1001"
+        def userId = 100L
+        def now = LocalDateTime.now()
+        def participants = [
+                new GetChatRoomDetailResult.ParticipantInfo(100L, true, now, now),
+                new GetChatRoomDetailResult.ParticipantInfo(200L, true, now, now)
+        ]
+        def result = new GetChatRoomDetailResult(
+                roomId,
+                ChatRoomType.DM,
+                "User2",
+                participants,
+                100L,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now,
+                0
+        )
+
+        getChatRoomDetailUseCase.execute(_) >> result
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.roomId').value(roomId))
+                .andExpect(jsonPath('$.data.type').value("DM"))
+                .andExpect(jsonPath('$.data.status').value("ACTIVE"))
+                .andExpect(jsonPath('$.data.participants').isArray())
+                .andExpect(jsonPath('$.data.participants.length()').value(2))
+    }
+
+    def "그룹 채팅방 상세 조회"() {
+        given:
+        def roomId = "1002"
+        def userId = 100L
+        def now = LocalDateTime.now()
+        def participants = [
+                new GetChatRoomDetailResult.ParticipantInfo(100L, true, now, now),
+                new GetChatRoomDetailResult.ParticipantInfo(200L, true, now, now),
+                new GetChatRoomDetailResult.ParticipantInfo(300L, false, null, now)
+        ]
+        def result = new GetChatRoomDetailResult(
+                roomId,
+                ChatRoomType.GROUP,
+                "개발팀",
+                participants,
+                100L,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now,
+                5
+        )
+
+        getChatRoomDetailUseCase.execute(_) >> result
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.data.type').value("GROUP"))
+                .andExpect(jsonPath('$.data.name').value("개발팀"))
+                .andExpect(jsonPath('$.data.participants.length()').value(3))
+    }
+
+    def "존재하지 않는 채팅방 상세 조회 시 404 반환"() {
+        given:
+        def roomId = "9999"
+        def userId = 100L
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        1 * getChatRoomDetailUseCase.execute(_) >> { throw new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND) }
+
+        and:
+        response.andExpect(status().isNotFound())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_001"))
+    }
+
+    def "참여하지 않은 채팅방 상세 조회 시 403 반환"() {
+        given:
+        def roomId = "1001"
+        def userId = 999L
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        1 * getChatRoomDetailUseCase.execute(_) >> { throw new ChatException(ErrorCode.CHAT_ROOM_ACCESS_DENIED) }
+
+        and:
+        response.andExpect(status().isForbidden())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_002"))
+    }
+
+    def "채팅방 상세 조회 시 X-User-Id 헤더 누락"() {
+        given:
+        def roomId = "1001"
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.error.code').value("MISSING_HEADER"))
+    }
+
+    def "상담 채팅방 상세 조회"() {
+        given:
+        def roomId = "2001"
+        def userId = 100L
+        def now = LocalDateTime.now()
+        def participants = [
+                new GetChatRoomDetailResult.ParticipantInfo(100L, true, now, now),
+                new GetChatRoomDetailResult.ParticipantInfo(500L, true, now, now)
+        ]
+        def result = new GetChatRoomDetailResult(
+                roomId,
+                ChatRoomType.SUPPORT,
+                "고객센터 상담",
+                participants,
+                500L,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now,
+                0
+        )
+
+        getChatRoomDetailUseCase.execute(_) >> result
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.data.type').value("SUPPORT"))
+                .andExpect(jsonPath('$.data.ownerId').value(500))
+    }
+}

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/controller/MessageControllerSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/controller/MessageControllerSpec.groovy
@@ -1,0 +1,276 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.teambind.co.kr.chatdding.adapter.in.web.GlobalExceptionHandler
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesResult
+import com.teambind.co.kr.chatdding.application.port.in.GetMessagesUseCase
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadResult
+import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadUseCase
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageResult
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageUseCase
+import com.teambind.co.kr.chatdding.common.exception.ChatException
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDateTime
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class MessageControllerSpec extends Specification {
+
+    SendMessageUseCase sendMessageUseCase = Mock()
+    GetMessagesUseCase getMessagesUseCase = Mock()
+    MarkAsReadUseCase markAsReadUseCase = Mock()
+    ObjectMapper objectMapper = new ObjectMapper()
+
+    @Subject
+    MessageController messageController
+
+    MockMvc mockMvc
+
+    def setup() {
+        messageController = new MessageController(sendMessageUseCase, getMessagesUseCase, markAsReadUseCase)
+        mockMvc = MockMvcBuilders.standaloneSetup(messageController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build()
+    }
+
+    def "메시지 전송 성공 시 201 Created 반환"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def content = "안녕하세요"
+        def result = new SendMessageResult("msg1", roomId, userId, content, LocalDateTime.now())
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"content": "안녕하세요"}'))
+
+        then:
+        1 * sendMessageUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isCreated())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.messageId').value("msg1"))
+                .andExpect(jsonPath('$.data.roomId').value(roomId))
+                .andExpect(jsonPath('$.data.senderId').value(userId))
+                .andExpect(jsonPath('$.data.content').value(content))
+    }
+
+    def "메시지 내용이 없으면 400 Bad Request 반환"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"content": ""}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("VALIDATION_ERROR"))
+    }
+
+    def "X-User-Id 헤더 누락 시 400 Bad Request 반환"() {
+        given:
+        def roomId = "123"
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages", roomId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"content": "안녕하세요"}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("MISSING_HEADER"))
+    }
+
+    def "존재하지 않는 채팅방에 메시지 전송 시 404 반환"() {
+        given:
+        def roomId = "999"
+        def userId = 100L
+
+        sendMessageUseCase.execute(_) >> { throw new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND) }
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"content": "테스트"}'))
+
+        then:
+        response.andExpect(status().isNotFound())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_001"))
+    }
+
+    def "참여하지 않은 채팅방에 메시지 전송 시 403 반환"() {
+        given:
+        def roomId = "123"
+        def userId = 999L
+
+        sendMessageUseCase.execute(_) >> { throw new ChatException(ErrorCode.CHAT_ROOM_ACCESS_DENIED) }
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"content": "테스트"}'))
+
+        then:
+        response.andExpect(status().isForbidden())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_002"))
+    }
+
+    def "메시지 목록 조회 성공"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def messages = [
+                new GetMessagesResult.MessageItem("msg1", roomId, userId, "메시지1", 1, LocalDateTime.now()),
+                new GetMessagesResult.MessageItem("msg2", roomId, userId, "메시지2", 2, LocalDateTime.now())
+        ]
+        def result = new GetMessagesResult(messages, "msg1", true)
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        1 * getMessagesUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.messages').isArray())
+                .andExpect(jsonPath('$.data.messages.length()').value(2))
+                .andExpect(jsonPath('$.data.hasMore').value(true))
+                .andExpect(jsonPath('$.data.nextCursor').value("msg1"))
+    }
+
+    def "메시지 목록 조회 시 cursor와 limit 파라미터 전달"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def result = new GetMessagesResult([], null, false)
+
+        getMessagesUseCase.execute(_) >> result
+
+        when:
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId)
+                .param("cursor", "msg10")
+                .param("limit", "20"))
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "빈 메시지 목록 조회"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def result = new GetMessagesResult([], null, false)
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId))
+
+        then:
+        1 * getMessagesUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.data.messages').isEmpty())
+                .andExpect(jsonPath('$.data.hasMore').value(false))
+    }
+
+    def "읽음 처리 성공"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def result = new MarkAsReadResult(roomId, userId, LocalDateTime.now(), 5)
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages/read", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+
+        then:
+        1 * markAsReadUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.roomId').value(roomId))
+                .andExpect(jsonPath('$.data.userId').value(userId))
+                .andExpect(jsonPath('$.data.readCount').value(5))
+    }
+
+    def "특정 메시지까지 읽음 처리"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def result = new MarkAsReadResult(roomId, userId, LocalDateTime.now(), 3)
+
+        markAsReadUseCase.execute(_) >> result
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages/read", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"lastMessageId": "5"}'))
+
+        then:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.data.readCount').value(3))
+    }
+
+    def "읽음 처리 시 존재하지 않는 채팅방이면 404 반환"() {
+        given:
+        def roomId = "999"
+        def userId = 100L
+
+        markAsReadUseCase.execute(_) >> { throw new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND) }
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages/read", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+
+        then:
+        response.andExpect(status().isNotFound())
+    }
+
+    def "메시지 내용이 5000자를 초과하면 400 Bad Request 반환"() {
+        given:
+        def roomId = "123"
+        def userId = 100L
+        def longContent = "가" * 5001
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/rooms/{roomId}/messages", roomId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\": \"${longContent}\"}"))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.error.code').value("VALIDATION_ERROR"))
+    }
+}

--- a/ChatDDing-service/src/test/java/com/teambind/co/kr/chatdding/ChatDDingServiceApplicationTests.java
+++ b/ChatDDing-service/src/test/java/com/teambind/co/kr/chatdding/ChatDDingServiceApplicationTests.java
@@ -2,12 +2,20 @@ package com.teambind.co.kr.chatdding;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@EmbeddedKafka(
+		partitions = 1,
+		topics = {"chat-message-sent", "chat-message-read"},
+		brokerProperties = {"listeners=PLAINTEXT://localhost:9093", "port=9093"}
+)
+@ActiveProfiles("test")
 class ChatDDingServiceApplicationTests {
-	
+
 	@Test
 	void contextLoads() {
 	}
-	
+
 }


### PR DESCRIPTION
## Summary
- Web Adapter Layer Spock 테스트 작성 완료
- MockMvc 기반 Controller 테스트 및 GlobalExceptionHandler 테스트 포함

## Changes
### Controller Tests
- `MessageControllerSpec`: 메시지 전송, 목록 조회, 읽음 처리 API 테스트
  - POST /api/v1/rooms/{roomId}/messages 성공/실패 케이스
  - GET /api/v1/rooms/{roomId}/messages 페이지네이션 테스트
  - POST /api/v1/rooms/{roomId}/messages/read 읽음 처리

- `ChatRoomControllerSpec`: 채팅방 목록/상세 조회 API 테스트
  - GET /api/v1/rooms 목록 조회
  - GET /api/v1/rooms/{roomId} 상세 조회
  - DM, GROUP, SUPPORT 타입별 테스트

### Exception Handler Tests
- `GlobalExceptionHandlerSpec`: 예외 처리 검증
  - ChatException 처리 (404, 403, 400 등)
  - MethodArgumentNotValidException 처리
  - MissingRequestHeaderException 처리
  - IllegalArgumentException 및 일반 Exception 처리

## Test Coverage
- 3개 테스트 클래스
- 32개 테스트 케이스
- 모든 테스트 통과

## Related Issues
- Closes #40 (MessageController 테스트)
- Closes #41 (ChatRoomController 테스트)
- Closes #42 (GlobalExceptionHandler 테스트)
- Part of #29 (Story)
- Part of #25 (Epic)