### PR TITLE
Epic #47: PLACE_INQUIRY 기능 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.42/8365263844ebb62398e0dc33057ba10ba472d3b8/lombok-1.18.42.jar" />
+        </processorPath>
+        <module name="ChatDDing.main" />
+        <module name="ChatDDing.test" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="ChatDDing" options="-parameters" />
+      <module name="ChatDDing.main" options="-parameters" />
+      <module name="ChatDDing.test" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/ChatDDing-service" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/ChatDDing-service" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/ChatDDing-service" />
+  </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">
     <entry key="Project Default">
       <profile-state>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/Chat-Server.iml" filepath="$PROJECT_DIR$/.idea/Chat-Server.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/ChatDDing.main.iml" filepath="$PROJECT_DIR$/.idea/modules/ChatDDing.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/ChatDDing.main.iml
+++ b/.idea/modules/ChatDDing.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../ChatDDing-service/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../ChatDDing-service/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/ChatDDing-service/build.gradle
+++ b/ChatDDing-service/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.5.9'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -28,7 +29,6 @@ repositories {
 dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
@@ -72,4 +72,26 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/config/**',
+                    '**/dto/**',
+                    '**/*Application*'
+            ])
+        }))
+    }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/InquiryController.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/controller/InquiryController.java
@@ -1,0 +1,72 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.controller;
+
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.ApiResponse;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.request.CreateInquiryRequest;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.response.CreateInquiryResponse;
+import com.teambind.co.kr.chatdding.adapter.in.web.dto.response.GetHostInquiriesResponse;
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryResult;
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryUseCase;
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 공간 문의 API Controller (Web Adapter)
+ */
+@RestController
+@RequestMapping("/api/v1/chat/inquiry")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final CreatePlaceInquiryUseCase createPlaceInquiryUseCase;
+    private final GetHostInquiriesUseCase getHostInquiriesUseCase;
+
+    /**
+     * 공간 문의 생성
+     *
+     * POST /api/v1/chat/inquiry
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateInquiryResponse>> createInquiry(
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody CreateInquiryRequest request
+    ) {
+        CreatePlaceInquiryResult result = createPlaceInquiryUseCase.execute(
+                request.toCommand(userId)
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(CreateInquiryResponse.from(result)));
+    }
+
+    /**
+     * 호스트 문의 목록 조회
+     *
+     * GET /api/v1/chat/inquiry/host
+     */
+    @GetMapping("/host")
+    public ResponseEntity<ApiResponse<GetHostInquiriesResponse>> getHostInquiries(
+            @RequestHeader("X-User-Id") Long hostId,
+            @RequestParam(required = false) Long placeId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        GetHostInquiriesResult result = getHostInquiriesUseCase.execute(
+                GetHostInquiriesQuery.of(hostId, placeId, cursor, limit)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(GetHostInquiriesResponse.from(result)));
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/request/CreateInquiryRequest.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/request/CreateInquiryRequest.java
@@ -1,0 +1,28 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto.request;
+
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 공간 문의 생성 Request DTO
+ */
+public record CreateInquiryRequest(
+        @NotNull(message = "placeId is required")
+        Long placeId,
+
+        @NotBlank(message = "placeName is required")
+        String placeName,
+
+        @NotNull(message = "hostId is required")
+        Long hostId,
+
+        @Size(max = 5000, message = "initialMessage must be less than 5000 characters")
+        String initialMessage
+) {
+
+    public CreatePlaceInquiryCommand toCommand(Long guestId) {
+        return CreatePlaceInquiryCommand.of(guestId, hostId, placeId, placeName, initialMessage);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/response/CreateInquiryResponse.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/response/CreateInquiryResponse.java
@@ -1,0 +1,39 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto.response;
+
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryResult;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공간 문의 생성 Response DTO
+ */
+public record CreateInquiryResponse(
+        String roomId,
+        String type,
+        ContextDto context,
+        LocalDateTime createdAt
+) {
+
+    public record ContextDto(
+            String contextType,
+            Long contextId,
+            String contextName
+    ) {
+        public static ContextDto from(CreatePlaceInquiryResult.ContextDto context) {
+            return new ContextDto(
+                    context.contextType(),
+                    context.contextId(),
+                    context.contextName()
+            );
+        }
+    }
+
+    public static CreateInquiryResponse from(CreatePlaceInquiryResult result) {
+        return new CreateInquiryResponse(
+                result.roomId(),
+                result.type(),
+                ContextDto.from(result.context()),
+                result.createdAt()
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/response/GetHostInquiriesResponse.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/adapter/in/web/dto/response/GetHostInquiriesResponse.java
@@ -1,0 +1,60 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.dto.response;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 호스트 문의 목록 Response DTO
+ */
+public record GetHostInquiriesResponse(
+        List<InquiryItemDto> inquiries,
+        String nextCursor,
+        boolean hasMore
+) {
+
+    public record InquiryItemDto(
+            String roomId,
+            Long guestId,
+            String guestNickname,
+            ContextDto context,
+            String lastMessage,
+            int unreadCount,
+            LocalDateTime lastMessageAt
+    ) {
+        public static InquiryItemDto from(GetHostInquiriesResult.InquiryItem item) {
+            return new InquiryItemDto(
+                    item.roomId(),
+                    item.guestId(),
+                    item.guestNickname(),
+                    item.context() != null ? ContextDto.from(item.context()) : null,
+                    item.lastMessage(),
+                    item.unreadCount(),
+                    item.lastMessageAt()
+            );
+        }
+    }
+
+    public record ContextDto(
+            String contextType,
+            Long contextId,
+            String contextName
+    ) {
+        public static ContextDto from(GetHostInquiriesResult.ContextDto context) {
+            return new ContextDto(
+                    context.contextType(),
+                    context.contextId(),
+                    context.contextName()
+            );
+        }
+    }
+
+    public static GetHostInquiriesResponse from(GetHostInquiriesResult result) {
+        List<InquiryItemDto> items = result.inquiries().stream()
+                .map(InquiryItemDto::from)
+                .toList();
+
+        return new GetHostInquiriesResponse(items, result.nextCursor(), result.hasMore());
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/CreatePlaceInquiryCommand.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/CreatePlaceInquiryCommand.java
@@ -1,0 +1,60 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+/**
+ * 공간 문의 생성 Command DTO
+ *
+ * @param guestId        문의자 (게스트) ID
+ * @param hostId         호스트 ID
+ * @param placeId        공간 ID
+ * @param placeName      공간 이름
+ * @param initialMessage 초기 메시지 (선택)
+ */
+public record CreatePlaceInquiryCommand(
+        UserId guestId,
+        UserId hostId,
+        Long placeId,
+        String placeName,
+        String initialMessage
+) {
+
+    public CreatePlaceInquiryCommand {
+        if (guestId == null) {
+            throw new IllegalArgumentException("guestId cannot be null");
+        }
+        if (hostId == null) {
+            throw new IllegalArgumentException("hostId cannot be null");
+        }
+        if (placeId == null || placeId <= 0) {
+            throw new IllegalArgumentException("placeId must be positive");
+        }
+        if (placeName == null || placeName.isBlank()) {
+            throw new IllegalArgumentException("placeName cannot be null or blank");
+        }
+    }
+
+    public static CreatePlaceInquiryCommand of(Long guestId, Long hostId, Long placeId, String placeName) {
+        return new CreatePlaceInquiryCommand(
+                UserId.of(guestId),
+                UserId.of(hostId),
+                placeId,
+                placeName,
+                null
+        );
+    }
+
+    public static CreatePlaceInquiryCommand of(Long guestId, Long hostId, Long placeId, String placeName, String initialMessage) {
+        return new CreatePlaceInquiryCommand(
+                UserId.of(guestId),
+                UserId.of(hostId),
+                placeId,
+                placeName,
+                initialMessage
+        );
+    }
+
+    public boolean hasInitialMessage() {
+        return initialMessage != null && !initialMessage.isBlank();
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/CreatePlaceInquiryResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/CreatePlaceInquiryResult.java
@@ -1,0 +1,40 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공간 문의 생성 Result DTO
+ */
+public record CreatePlaceInquiryResult(
+        String roomId,
+        String type,
+        ContextDto context,
+        LocalDateTime createdAt
+) {
+
+    public record ContextDto(
+            String contextType,
+            Long contextId,
+            String contextName
+    ) {
+        public static ContextDto from(ChatRoomContext context) {
+            return new ContextDto(
+                    context.contextType().name(),
+                    context.contextId(),
+                    context.contextName()
+            );
+        }
+    }
+
+    public static CreatePlaceInquiryResult from(ChatRoom chatRoom) {
+        return new CreatePlaceInquiryResult(
+                chatRoom.getId().toStringValue(),
+                chatRoom.getType().name(),
+                ContextDto.from(chatRoom.getContext()),
+                chatRoom.getCreatedAt()
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/CreatePlaceInquiryUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/CreatePlaceInquiryUseCase.java
@@ -1,0 +1,15 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+/**
+ * 공간 문의 생성 UseCase
+ */
+public interface CreatePlaceInquiryUseCase {
+
+    /**
+     * 공간 문의 채팅방을 생성합니다.
+     *
+     * @param command 생성 요청 정보
+     * @return 생성된 채팅방 정보
+     */
+    CreatePlaceInquiryResult execute(CreatePlaceInquiryCommand command);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetHostInquiriesQuery.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetHostInquiriesQuery.java
@@ -1,0 +1,48 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+/**
+ * 호스트 문의 목록 조회 Query DTO
+ *
+ * @param hostId  호스트 ID
+ * @param placeId 공간 ID (선택, 필터링용)
+ * @param cursor  페이지네이션 커서 (선택)
+ * @param limit   조회 개수
+ */
+public record GetHostInquiriesQuery(
+        UserId hostId,
+        Long placeId,
+        String cursor,
+        int limit
+) {
+
+    public GetHostInquiriesQuery {
+        if (hostId == null) {
+            throw new IllegalArgumentException("hostId cannot be null");
+        }
+        if (limit <= 0 || limit > 100) {
+            limit = 20;
+        }
+    }
+
+    public static GetHostInquiriesQuery of(Long hostId) {
+        return new GetHostInquiriesQuery(UserId.of(hostId), null, null, 20);
+    }
+
+    public static GetHostInquiriesQuery of(Long hostId, Long placeId) {
+        return new GetHostInquiriesQuery(UserId.of(hostId), placeId, null, 20);
+    }
+
+    public static GetHostInquiriesQuery of(Long hostId, Long placeId, String cursor, int limit) {
+        return new GetHostInquiriesQuery(UserId.of(hostId), placeId, cursor, limit);
+    }
+
+    public boolean hasPlaceIdFilter() {
+        return placeId != null;
+    }
+
+    public boolean hasCursor() {
+        return cursor != null && !cursor.isBlank();
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetHostInquiriesResult.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetHostInquiriesResult.java
@@ -1,0 +1,66 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 호스트 문의 목록 조회 Result DTO
+ */
+public record GetHostInquiriesResult(
+        List<InquiryItem> inquiries,
+        String nextCursor,
+        boolean hasMore
+) {
+
+    public record InquiryItem(
+            String roomId,
+            Long guestId,
+            String guestNickname,
+            ContextDto context,
+            String lastMessage,
+            int unreadCount,
+            LocalDateTime lastMessageAt
+    ) {
+
+        public static InquiryItem from(ChatRoom chatRoom, Long guestId, int unreadCount) {
+            return new InquiryItem(
+                    chatRoom.getId().toStringValue(),
+                    guestId,
+                    null,  // nickname은 별도 조회 필요
+                    ContextDto.from(chatRoom.getContext()),
+                    null,  // lastMessage는 별도 조회 필요
+                    unreadCount,
+                    chatRoom.getLastMessageAt()
+            );
+        }
+    }
+
+    public record ContextDto(
+            String contextType,
+            Long contextId,
+            String contextName
+    ) {
+        public static ContextDto from(ChatRoomContext context) {
+            if (context == null) {
+                return null;
+            }
+            return new ContextDto(
+                    context.contextType().name(),
+                    context.contextId(),
+                    context.contextName()
+            );
+        }
+    }
+
+    public static GetHostInquiriesResult of(List<InquiryItem> inquiries, String nextCursor, boolean hasMore) {
+        return new GetHostInquiriesResult(inquiries, nextCursor, hasMore);
+    }
+
+    public static GetHostInquiriesResult empty() {
+        return new GetHostInquiriesResult(List.of(), null, false);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetHostInquiriesUseCase.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/in/GetHostInquiriesUseCase.java
@@ -1,0 +1,15 @@
+package com.teambind.co.kr.chatdding.application.port.in;
+
+/**
+ * 호스트 문의 목록 조회 UseCase
+ */
+public interface GetHostInquiriesUseCase {
+
+    /**
+     * 호스트의 공간 문의 목록을 조회합니다.
+     *
+     * @param query 조회 조건
+     * @return 문의 목록
+     */
+    GetHostInquiriesResult execute(GetHostInquiriesQuery query);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/CreatePlaceInquiryService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/CreatePlaceInquiryService.java
@@ -1,0 +1,81 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryCommand;
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryResult;
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryUseCase;
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageCommand;
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageUseCase;
+import com.teambind.co.kr.chatdding.application.port.out.EventPublisher;
+import com.teambind.co.kr.chatdding.common.exception.ChatException;
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
+import com.teambind.co.kr.chatdding.common.util.generator.PrimaryKeyGenerator;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.event.InquiryCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 공간 문의 생성 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreatePlaceInquiryService implements CreatePlaceInquiryUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final PrimaryKeyGenerator primaryKeyGenerator;
+    private final EventPublisher eventPublisher;
+    private final SendMessageUseCase sendMessageUseCase;
+
+    @Override
+    public CreatePlaceInquiryResult execute(CreatePlaceInquiryCommand command) {
+        validateDuplicateInquiry(command);
+
+        ChatRoom chatRoom = createAndSaveChatRoom(command);
+        sendInitialMessageIfPresent(command, chatRoom);
+        publishInquiryCreatedEvent(chatRoom);
+
+        return CreatePlaceInquiryResult.from(chatRoom);
+    }
+
+    private void validateDuplicateInquiry(CreatePlaceInquiryCommand command) {
+        chatRoomRepository.findPlaceInquiryByPlaceIdAndGuestId(command.placeId(), command.guestId())
+                .ifPresent(existing -> {
+                    throw ChatException.of(ErrorCode.DUPLICATE_INQUIRY);
+                });
+    }
+
+    private ChatRoom createAndSaveChatRoom(CreatePlaceInquiryCommand command) {
+        RoomId roomId = RoomId.of(primaryKeyGenerator.generateLongKey());
+        ChatRoomContext context = ChatRoomContext.forPlace(command.placeId(), command.placeName());
+
+        ChatRoom chatRoom = ChatRoom.createPlaceInquiry(
+                roomId,
+                command.guestId(),
+                command.hostId(),
+                context
+        );
+
+        return chatRoomRepository.save(chatRoom);
+    }
+
+    private void sendInitialMessageIfPresent(CreatePlaceInquiryCommand command, ChatRoom chatRoom) {
+        if (command.hasInitialMessage()) {
+            SendMessageCommand messageCommand = new SendMessageCommand(
+                    chatRoom.getId(),
+                    command.guestId(),
+                    command.initialMessage()
+            );
+            sendMessageUseCase.execute(messageCommand);
+        }
+    }
+
+    private void publishInquiryCreatedEvent(ChatRoom chatRoom) {
+        InquiryCreatedEvent event = InquiryCreatedEvent.from(chatRoom);
+        eventPublisher.publish(event);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetHostInquiriesService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetHostInquiriesService.java
@@ -1,0 +1,66 @@
+package com.teambind.co.kr.chatdding.application.service;
+
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesQuery;
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesResult;
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesResult.InquiryItem;
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesUseCase;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 호스트 문의 목록 조회 UseCase 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetHostInquiriesService implements GetHostInquiriesUseCase {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
+
+    @Override
+    public GetHostInquiriesResult execute(GetHostInquiriesQuery query) {
+        List<ChatRoom> inquiries = chatRoomRepository.findPlaceInquiriesByHostId(
+                query.hostId(),
+                query.placeId()
+        );
+
+        if (inquiries.isEmpty()) {
+            return GetHostInquiriesResult.empty();
+        }
+
+        List<InquiryItem> items = inquiries.stream()
+                .map(chatRoom -> toInquiryItem(chatRoom, query.hostId()))
+                .limit(query.limit())
+                .toList();
+
+        boolean hasMore = inquiries.size() > query.limit();
+        String nextCursor = hasMore && !items.isEmpty()
+                ? items.get(items.size() - 1).roomId()
+                : null;
+
+        return GetHostInquiriesResult.of(items, nextCursor, hasMore);
+    }
+
+    private InquiryItem toInquiryItem(ChatRoom chatRoom, UserId hostId) {
+        Long guestId = chatRoom.getParticipantIds().stream()
+                .filter(userId -> !userId.equals(hostId))
+                .findFirst()
+                .map(UserId::getValue)
+                .orElse(null);
+
+        int unreadCount = (int) messageRepository.countUnreadByRoomIdAndUserId(
+                chatRoom.getId(),
+                hostId
+        );
+
+        return InquiryItem.from(chatRoom, guestId, unreadCount);
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/common/exception/ErrorCode.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/common/exception/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     // Support Errors
     SUPPORT_ALREADY_IN_PROGRESS("CHAT_010", HttpStatus.CONFLICT, "이미 진행 중인 상담이 있습니다"),
 
+    // Inquiry Errors
+    DUPLICATE_INQUIRY("CHAT_011", HttpStatus.CONFLICT, "해당 공간에 이미 문의 채팅방이 존재합니다"),
+
     // Internal Errors
     INTERNAL_SERVER_ERROR("CHAT_500", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoom.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoom.java
@@ -27,11 +27,12 @@ public class ChatRoom {
     private ChatRoomStatus status;
     private final LocalDateTime createdAt;
     private LocalDateTime lastMessageAt;
+    private final ChatRoomContext context;
 
     private ChatRoom(RoomId id, ChatRoomType type, String name,
                      List<Participant> participants, UserId ownerId,
                      ChatRoomStatus status, LocalDateTime createdAt,
-                     LocalDateTime lastMessageAt) {
+                     LocalDateTime lastMessageAt, ChatRoomContext context) {
         this.id = id;
         this.type = type;
         this.name = name;
@@ -40,6 +41,7 @@ public class ChatRoom {
         this.status = status;
         this.createdAt = createdAt;
         this.lastMessageAt = lastMessageAt;
+        this.context = context;
     }
 
     /**
@@ -64,7 +66,8 @@ public class ChatRoom {
                 senderId,
                 ChatRoomStatus.ACTIVE,
                 now,
-                now
+                now,
+                null
         );
     }
 
@@ -94,7 +97,8 @@ public class ChatRoom {
                 ownerId,
                 ChatRoomStatus.ACTIVE,
                 now,
-                now
+                now,
+                null
         );
     }
 
@@ -116,7 +120,43 @@ public class ChatRoom {
                 userId,
                 ChatRoomStatus.ACTIVE,
                 now,
-                now
+                now,
+                null
+        );
+    }
+
+    /**
+     * 공간 문의 채팅방 생성
+     *
+     * @param id       Snowflake로 생성된 RoomId
+     * @param guestId  문의자 (게스트) ID
+     * @param hostId   호스트 ID
+     * @param context  공간 컨텍스트 정보
+     */
+    public static ChatRoom createPlaceInquiry(RoomId id, UserId guestId, UserId hostId, ChatRoomContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("context must not be null for PLACE_INQUIRY");
+        }
+        if (!context.isPlaceContext()) {
+            throw new IllegalArgumentException("context must be PLACE type for PLACE_INQUIRY");
+        }
+
+        List<Participant> participants = List.of(
+                Participant.create(guestId),
+                Participant.create(hostId)
+        );
+
+        LocalDateTime now = LocalDateTime.now();
+        return new ChatRoom(
+                id,
+                ChatRoomType.PLACE_INQUIRY,
+                context.contextName(),
+                participants,
+                hostId,
+                ChatRoomStatus.ACTIVE,
+                now,
+                now,
+                context
         );
     }
 
@@ -126,8 +166,8 @@ public class ChatRoom {
     public static ChatRoom restore(RoomId id, ChatRoomType type, String name,
                                     List<Participant> participants, UserId ownerId,
                                     ChatRoomStatus status, LocalDateTime createdAt,
-                                    LocalDateTime lastMessageAt) {
-        return new ChatRoom(id, type, name, participants, ownerId, status, createdAt, lastMessageAt);
+                                    LocalDateTime lastMessageAt, ChatRoomContext context) {
+        return new ChatRoom(id, type, name, participants, ownerId, status, createdAt, lastMessageAt, context);
     }
 
     /**

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomContext.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomContext.java
@@ -1,0 +1,63 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 채팅방 컨텍스트 Value Object
+ *
+ * <p>채팅방이 특정 도메인(공간, 주문, 예약 등)과 연결될 때 해당 정보를 저장</p>
+ */
+public record ChatRoomContext(
+        ContextType contextType,
+        Long contextId,
+        String contextName,
+        Map<String, Object> metadata
+) {
+
+    public ChatRoomContext {
+        Objects.requireNonNull(contextType, "contextType must not be null");
+        Objects.requireNonNull(contextId, "contextId must not be null");
+        if (contextId <= 0) {
+            throw new IllegalArgumentException("contextId must be positive");
+        }
+        metadata = metadata != null ? Collections.unmodifiableMap(new HashMap<>(metadata)) : Map.of();
+    }
+
+    /**
+     * 공간 문의용 컨텍스트 생성
+     */
+    public static ChatRoomContext forPlace(Long placeId, String placeName) {
+        return new ChatRoomContext(ContextType.PLACE, placeId, placeName, Map.of());
+    }
+
+    /**
+     * 공간 문의용 컨텍스트 생성 (메타데이터 포함)
+     */
+    public static ChatRoomContext forPlace(Long placeId, String placeName, Map<String, Object> metadata) {
+        return new ChatRoomContext(ContextType.PLACE, placeId, placeName, metadata);
+    }
+
+    /**
+     * 주문 관련 컨텍스트 생성
+     */
+    public static ChatRoomContext forOrder(Long orderId, String orderName) {
+        return new ChatRoomContext(ContextType.ORDER, orderId, orderName, Map.of());
+    }
+
+    /**
+     * 예약 관련 컨텍스트 생성
+     */
+    public static ChatRoomContext forBooking(Long bookingId, String bookingName) {
+        return new ChatRoomContext(ContextType.BOOKING, bookingId, bookingName, Map.of());
+    }
+
+    /**
+     * 공간 컨텍스트인지 확인
+     */
+    public boolean isPlaceContext() {
+        return contextType == ContextType.PLACE;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomRepository.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomRepository.java
@@ -49,4 +49,22 @@ public interface ChatRoomRepository {
      * 채팅방 삭제
      */
     void deleteById(RoomId roomId);
+
+    /**
+     * 공간 문의 중복 체크: 동일한 게스트-공간 조합의 문의가 존재하는지 확인
+     *
+     * @param placeId 공간 ID
+     * @param guestId 게스트 ID
+     * @return 기존 문의 채팅방 (있는 경우)
+     */
+    Optional<ChatRoom> findPlaceInquiryByPlaceIdAndGuestId(Long placeId, UserId guestId);
+
+    /**
+     * 호스트의 공간 문의 목록 조회
+     *
+     * @param hostId  호스트 ID
+     * @param placeId 공간 ID (nullable, 필터링용)
+     * @return 문의 채팅방 목록
+     */
+    List<ChatRoom> findPlaceInquiriesByHostId(UserId hostId, Long placeId);
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomType.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomType.java
@@ -12,10 +12,18 @@ public enum ChatRoomType {
 
     DM("1:1 개인 대화", 2),
     GROUP("그룹 채팅", 100),
+    PLACE_INQUIRY("공간 문의", 2),
     SUPPORT("고객 상담", 2);
 
     private final String description;
     private final int maxParticipants;
+
+    /**
+     * 컨텍스트가 필요한 채팅방 유형인지 확인
+     */
+    public boolean requiresContext() {
+        return this == PLACE_INQUIRY;
+    }
 
     public boolean canAddParticipant(int currentCount) {
         return currentCount < maxParticipants;

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ContextType.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/chatroom/ContextType.java
@@ -1,0 +1,20 @@
+package com.teambind.co.kr.chatdding.domain.chatroom;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채팅방 컨텍스트 유형
+ *
+ * <p>채팅방이 어떤 도메인과 연결되어 있는지 나타냄</p>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ContextType {
+
+    PLACE("공간 문의"),
+    ORDER("주문 관련"),
+    BOOKING("예약 관련");
+
+    private final String description;
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/InquiryCreatedEvent.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/domain/event/InquiryCreatedEvent.java
@@ -1,0 +1,58 @@
+package com.teambind.co.kr.chatdding.domain.event;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공간 문의 생성 이벤트
+ */
+public record InquiryCreatedEvent(
+        String roomId,
+        Long guestId,
+        Long hostId,
+        ContextInfo context,
+        LocalDateTime occurredAt
+) implements ChatEvent {
+
+    public static final String EVENT_TYPE = "INQUIRY_CREATED";
+
+    public record ContextInfo(
+            String contextType,
+            Long contextId,
+            String contextName
+    ) {
+        public static ContextInfo from(ChatRoomContext context) {
+            return new ContextInfo(
+                    context.contextType().name(),
+                    context.contextId(),
+                    context.contextName()
+            );
+        }
+    }
+
+    public static InquiryCreatedEvent from(ChatRoom chatRoom) {
+        return new InquiryCreatedEvent(
+                chatRoom.getId().toStringValue(),
+                chatRoom.getParticipantIds().stream()
+                        .filter(userId -> !userId.equals(chatRoom.getOwnerId()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue(),
+                chatRoom.getOwnerId().getValue(),
+                ContextInfo.from(chatRoom.getContext()),
+                chatRoom.getCreatedAt()
+        );
+    }
+
+    @Override
+    public String getEventType() {
+        return EVENT_TYPE;
+    }
+
+    @Override
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/adapter/ChatRoomRepositoryAdapter.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/adapter/ChatRoomRepositoryAdapter.java
@@ -70,4 +70,27 @@ public class ChatRoomRepositoryAdapter implements ChatRoomRepository {
     public void deleteById(RoomId roomId) {
         mongoRepository.deleteById(roomId.getValue());
     }
+
+    @Override
+    public Optional<ChatRoom> findPlaceInquiryByPlaceIdAndGuestId(Long placeId, UserId guestId) {
+        return mongoRepository.findByTypeAndContext_ContextIdAndParticipantIdsContaining(
+                        ChatRoomType.PLACE_INQUIRY, placeId, guestId.getValue())
+                .map(ChatRoomDocument::toDomain);
+    }
+
+    @Override
+    public List<ChatRoom> findPlaceInquiriesByHostId(UserId hostId, Long placeId) {
+        if (placeId != null) {
+            return mongoRepository.findByTypeAndOwnerIdAndContext_ContextIdOrderByLastMessageAtDesc(
+                            ChatRoomType.PLACE_INQUIRY, hostId.getValue(), placeId)
+                    .stream()
+                    .map(ChatRoomDocument::toDomain)
+                    .toList();
+        }
+        return mongoRepository.findByTypeAndOwnerIdOrderByLastMessageAtDesc(
+                        ChatRoomType.PLACE_INQUIRY, hostId.getValue())
+                .stream()
+                .map(ChatRoomDocument::toDomain)
+                .toList();
+    }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/document/ChatRoomContextDocument.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/document/ChatRoomContextDocument.java
@@ -1,0 +1,49 @@
+package com.teambind.co.kr.chatdding.infrastructure.persistence.mongodb.document;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext;
+import com.teambind.co.kr.chatdding.domain.chatroom.ContextType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * 채팅방 컨텍스트 MongoDB Document
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomContextDocument {
+
+    private String contextType;
+
+    private Long contextId;
+
+    private String contextName;
+
+    private Map<String, Object> metadata;
+
+    public static ChatRoomContextDocument from(ChatRoomContext context) {
+        if (context == null) {
+            return null;
+        }
+        return ChatRoomContextDocument.builder()
+                .contextType(context.contextType().name())
+                .contextId(context.contextId())
+                .contextName(context.contextName())
+                .metadata(context.metadata())
+                .build();
+    }
+
+    public ChatRoomContext toDomain() {
+        return new ChatRoomContext(
+                ContextType.valueOf(contextType),
+                contextId,
+                contextName,
+                metadata
+        );
+    }
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/document/ChatRoomDocument.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/document/ChatRoomDocument.java
@@ -1,6 +1,7 @@
 package com.teambind.co.kr.chatdding.infrastructure.persistence.mongodb.document;
 
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext;
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomStatus;
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType;
 import com.teambind.co.kr.chatdding.domain.chatroom.Participant;
@@ -56,6 +57,8 @@ public class ChatRoomDocument {
     @Indexed
     private LocalDateTime lastMessageAt;
 
+    private ChatRoomContextDocument context;
+
     public static ChatRoomDocument from(ChatRoom chatRoom) {
         List<ParticipantDocument> participantDocs = chatRoom.getParticipants().stream()
                 .map(ParticipantDocument::from)
@@ -76,6 +79,7 @@ public class ChatRoomDocument {
                 .status(chatRoom.getStatus())
                 .createdAt(chatRoom.getCreatedAt())
                 .lastMessageAt(chatRoom.getLastMessageAt())
+                .context(ChatRoomContextDocument.from(chatRoom.getContext()))
                 .build();
     }
 
@@ -83,6 +87,8 @@ public class ChatRoomDocument {
         List<Participant> domainParticipants = participants.stream()
                 .map(ParticipantDocument::toDomain)
                 .toList();
+
+        ChatRoomContext domainContext = context != null ? context.toDomain() : null;
 
         return ChatRoom.restore(
                 RoomId.of(id),
@@ -92,7 +98,8 @@ public class ChatRoomDocument {
                 UserId.of(ownerId),
                 status,
                 createdAt,
-                lastMessageAt
+                lastMessageAt,
+                domainContext
         );
     }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/repository/ChatRoomMongoRepository.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/persistence/mongodb/repository/ChatRoomMongoRepository.java
@@ -20,4 +20,22 @@ public interface ChatRoomMongoRepository extends MongoRepository<ChatRoomDocumen
 
     Optional<ChatRoomDocument> findByTypeAndSortedParticipantIds(
             ChatRoomType type, List<Long> sortedParticipantIds);
+
+    /**
+     * 공간 문의 중복 체크: 동일 게스트-공간 조합 조회
+     */
+    Optional<ChatRoomDocument> findByTypeAndContext_ContextIdAndParticipantIdsContaining(
+            ChatRoomType type, Long contextId, Long participantId);
+
+    /**
+     * 호스트의 공간 문의 목록 조회
+     */
+    List<ChatRoomDocument> findByTypeAndOwnerIdOrderByLastMessageAtDesc(
+            ChatRoomType type, Long ownerId);
+
+    /**
+     * 호스트의 특정 공간 문의 목록 조회
+     */
+    List<ChatRoomDocument> findByTypeAndOwnerIdAndContext_ContextIdOrderByLastMessageAtDesc(
+            ChatRoomType type, Long ownerId, Long contextId);
 }

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/controller/InquiryControllerSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/adapter/in/web/controller/InquiryControllerSpec.groovy
@@ -1,0 +1,233 @@
+package com.teambind.co.kr.chatdding.adapter.in.web.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.teambind.co.kr.chatdding.adapter.in.web.GlobalExceptionHandler
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryResult
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryUseCase
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesResult
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesUseCase
+import com.teambind.co.kr.chatdding.common.exception.ChatException
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDateTime
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class InquiryControllerSpec extends Specification {
+
+    CreatePlaceInquiryUseCase createPlaceInquiryUseCase = Mock()
+    GetHostInquiriesUseCase getHostInquiriesUseCase = Mock()
+    ObjectMapper objectMapper = new ObjectMapper()
+
+    @Subject
+    InquiryController inquiryController
+
+    MockMvc mockMvc
+
+    def setup() {
+        inquiryController = new InquiryController(createPlaceInquiryUseCase, getHostInquiriesUseCase)
+        mockMvc = MockMvcBuilders.standaloneSetup(inquiryController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build()
+    }
+
+    // ========================
+    // POST /api/v1/chat/inquiry
+    // ========================
+
+    def "공간 문의 생성 성공 시 201 Created 반환"() {
+        given:
+        def userId = 100L
+        def contextDto = new CreatePlaceInquiryResult.ContextDto("PLACE", 12345L, "강남 스터디룸 A")
+        def result = new CreatePlaceInquiryResult("999", "PLACE_INQUIRY", contextDto, LocalDateTime.now())
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/chat/inquiry")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"placeId": 12345, "placeName": "강남 스터디룸 A", "hostId": 200}'))
+
+        then:
+        1 * createPlaceInquiryUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isCreated())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.roomId').value("999"))
+                .andExpect(jsonPath('$.data.type').value("PLACE_INQUIRY"))
+                .andExpect(jsonPath('$.data.context.contextType').value("PLACE"))
+                .andExpect(jsonPath('$.data.context.contextId').value(12345))
+                .andExpect(jsonPath('$.data.context.contextName').value("강남 스터디룸 A"))
+    }
+
+    def "초기 메시지 포함하여 공간 문의 생성"() {
+        given:
+        def userId = 100L
+        def contextDto = new CreatePlaceInquiryResult.ContextDto("PLACE", 12345L, "강남 스터디룸 A")
+        def result = new CreatePlaceInquiryResult("999", "PLACE_INQUIRY", contextDto, LocalDateTime.now())
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/chat/inquiry")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"placeId": 12345, "placeName": "강남 스터디룸 A", "hostId": 200, "initialMessage": "예약 문의드립니다"}'))
+
+        then:
+        1 * createPlaceInquiryUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isCreated())
+    }
+
+    def "placeId 누락 시 400 Bad Request 반환"() {
+        given:
+        def userId = 100L
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/chat/inquiry")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"placeName": "강남 스터디룸 A", "hostId": 200}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+    }
+
+    def "hostId 누락 시 400 Bad Request 반환"() {
+        given:
+        def userId = 100L
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/chat/inquiry")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"placeId": 12345, "placeName": "강남 스터디룸 A"}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.success').value(false))
+    }
+
+    def "X-User-Id 헤더 누락 시 400 Bad Request 반환"() {
+        when:
+        def response = mockMvc.perform(post("/api/v1/chat/inquiry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"placeId": 12345, "placeName": "강남 스터디룸 A", "hostId": 200}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.error.code').value("MISSING_HEADER"))
+    }
+
+    def "중복 문의 시 409 Conflict 반환"() {
+        given:
+        def userId = 100L
+
+        when:
+        def response = mockMvc.perform(post("/api/v1/chat/inquiry")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"placeId": 12345, "placeName": "강남 스터디룸 A", "hostId": 200}'))
+
+        then:
+        1 * createPlaceInquiryUseCase.execute(_) >> { throw new ChatException(ErrorCode.DUPLICATE_INQUIRY) }
+
+        and:
+        response.andExpect(status().isConflict())
+                .andExpect(jsonPath('$.success').value(false))
+                .andExpect(jsonPath('$.error.code').value("CHAT_011"))
+    }
+
+    // ========================
+    // GET /api/v1/chat/inquiry/host
+    // ========================
+
+    def "호스트 문의 목록 조회 성공"() {
+        given:
+        def hostId = 200L
+        def contextDto = new GetHostInquiriesResult.ContextDto("PLACE", 12345L, "강남 스터디룸 A")
+        def inquiryItem = new GetHostInquiriesResult.InquiryItem(
+                "999", 100L, "게스트닉네임", contextDto, "마지막 메시지", 3, LocalDateTime.now()
+        )
+        def result = new GetHostInquiriesResult([inquiryItem], null, false)
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/chat/inquiry/host")
+                .header("X-User-Id", hostId))
+
+        then:
+        1 * getHostInquiriesUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.success').value(true))
+                .andExpect(jsonPath('$.data.inquiries').isArray())
+                .andExpect(jsonPath('$.data.inquiries.length()').value(1))
+                .andExpect(jsonPath('$.data.inquiries[0].roomId').value("999"))
+                .andExpect(jsonPath('$.data.inquiries[0].guestId').value(100))
+                .andExpect(jsonPath('$.data.inquiries[0].unreadCount').value(3))
+                .andExpect(jsonPath('$.data.hasMore').value(false))
+    }
+
+    def "placeId 필터로 문의 목록 조회"() {
+        given:
+        def hostId = 200L
+        def result = GetHostInquiriesResult.empty()
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/chat/inquiry/host")
+                .header("X-User-Id", hostId)
+                .param("placeId", "12345"))
+
+        then:
+        1 * getHostInquiriesUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+    }
+
+    def "빈 문의 목록 조회"() {
+        given:
+        def hostId = 200L
+        def result = GetHostInquiriesResult.empty()
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/chat/inquiry/host")
+                .header("X-User-Id", hostId))
+
+        then:
+        1 * getHostInquiriesUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.data.inquiries').isEmpty())
+                .andExpect(jsonPath('$.data.hasMore').value(false))
+    }
+
+    def "페이지네이션 파라미터 전달"() {
+        given:
+        def hostId = 200L
+        def result = GetHostInquiriesResult.empty()
+
+        when:
+        def response = mockMvc.perform(get("/api/v1/chat/inquiry/host")
+                .header("X-User-Id", hostId)
+                .param("cursor", "abc123")
+                .param("limit", "10"))
+
+        then:
+        1 * getHostInquiriesUseCase.execute(_) >> result
+
+        and:
+        response.andExpect(status().isOk())
+    }
+}

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/CreatePlaceInquiryServiceSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/CreatePlaceInquiryServiceSpec.groovy
@@ -1,0 +1,119 @@
+package com.teambind.co.kr.chatdding.application.service
+
+import com.teambind.co.kr.chatdding.application.port.in.CreatePlaceInquiryCommand
+import com.teambind.co.kr.chatdding.application.port.in.SendMessageUseCase
+import com.teambind.co.kr.chatdding.application.port.out.EventPublisher
+import com.teambind.co.kr.chatdding.common.exception.ChatException
+import com.teambind.co.kr.chatdding.common.exception.ErrorCode
+import com.teambind.co.kr.chatdding.common.util.generator.PrimaryKeyGenerator
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomType
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId
+import com.teambind.co.kr.chatdding.domain.common.UserId
+import com.teambind.co.kr.chatdding.domain.event.InquiryCreatedEvent
+import spock.lang.Specification
+import spock.lang.Subject
+
+class CreatePlaceInquiryServiceSpec extends Specification {
+
+    ChatRoomRepository chatRoomRepository = Mock()
+    PrimaryKeyGenerator primaryKeyGenerator = Mock()
+    EventPublisher eventPublisher = Mock()
+    SendMessageUseCase sendMessageUseCase = Mock()
+
+    @Subject
+    CreatePlaceInquiryService service
+
+    def setup() {
+        service = new CreatePlaceInquiryService(
+                chatRoomRepository,
+                primaryKeyGenerator,
+                eventPublisher,
+                sendMessageUseCase
+        )
+    }
+
+    def "공간 문의 채팅방을 성공적으로 생성한다"() {
+        given:
+        def command = CreatePlaceInquiryCommand.of(100L, 200L, 12345L, "강남 스터디룸 A")
+
+        primaryKeyGenerator.generateLongKey() >> 999L
+        chatRoomRepository.findPlaceInquiryByPlaceIdAndGuestId(12345L, UserId.of(100L)) >> Optional.empty()
+        chatRoomRepository.save(_) >> { ChatRoom room -> room }
+
+        when:
+        def result = service.execute(command)
+
+        then:
+        result.roomId() != null
+        result.type() == "PLACE_INQUIRY"
+        result.context().contextType() == "PLACE"
+        result.context().contextId() == 12345L
+        result.context().contextName() == "강남 스터디룸 A"
+
+        and:
+        1 * eventPublisher.publish(_ as InquiryCreatedEvent)
+    }
+
+    def "초기 메시지가 있으면 메시지도 함께 전송한다"() {
+        given:
+        def command = CreatePlaceInquiryCommand.of(100L, 200L, 12345L, "강남 스터디룸 A", "예약 문의드립니다")
+
+        primaryKeyGenerator.generateLongKey() >> 999L
+        chatRoomRepository.findPlaceInquiryByPlaceIdAndGuestId(12345L, UserId.of(100L)) >> Optional.empty()
+        chatRoomRepository.save(_) >> { ChatRoom room -> room }
+
+        when:
+        service.execute(command)
+
+        then:
+        1 * sendMessageUseCase.execute(_)
+        1 * eventPublisher.publish(_ as InquiryCreatedEvent)
+    }
+
+    def "중복 문의가 있으면 예외가 발생한다"() {
+        given:
+        def command = CreatePlaceInquiryCommand.of(100L, 200L, 12345L, "강남 스터디룸 A")
+
+        def existingRoom = ChatRoom.createPlaceInquiry(
+                RoomId.of(888L),
+                UserId.of(100L),
+                UserId.of(200L),
+                ChatRoomContext.forPlace(12345L, "강남 스터디룸 A")
+        )
+        chatRoomRepository.findPlaceInquiryByPlaceIdAndGuestId(12345L, UserId.of(100L)) >> Optional.of(existingRoom)
+
+        when:
+        service.execute(command)
+
+        then:
+        def ex = thrown(ChatException)
+        ex.errorCode == ErrorCode.DUPLICATE_INQUIRY
+    }
+
+    def "guestId가 null이면 예외가 발생한다"() {
+        when:
+        CreatePlaceInquiryCommand.of(null, 200L, 12345L, "테스트")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "placeId가 0 이하이면 예외가 발생한다"() {
+        when:
+        CreatePlaceInquiryCommand.of(100L, 200L, 0L, "테스트")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "placeName이 비어있으면 예외가 발생한다"() {
+        when:
+        CreatePlaceInquiryCommand.of(100L, 200L, 12345L, "")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/GetHostInquiriesServiceSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/GetHostInquiriesServiceSpec.groovy
@@ -1,0 +1,119 @@
+package com.teambind.co.kr.chatdding.application.service
+
+import com.teambind.co.kr.chatdding.application.port.in.GetHostInquiriesQuery
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomContext
+import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId
+import com.teambind.co.kr.chatdding.domain.common.UserId
+import com.teambind.co.kr.chatdding.domain.message.MessageRepository
+import spock.lang.Specification
+import spock.lang.Subject
+
+class GetHostInquiriesServiceSpec extends Specification {
+
+    ChatRoomRepository chatRoomRepository = Mock()
+    MessageRepository messageRepository = Mock()
+
+    @Subject
+    GetHostInquiriesService service
+
+    def setup() {
+        service = new GetHostInquiriesService(chatRoomRepository, messageRepository)
+    }
+
+    def "호스트의 문의 목록을 조회한다"() {
+        given:
+        def query = GetHostInquiriesQuery.of(200L)
+        def chatRoom = ChatRoom.createPlaceInquiry(
+                RoomId.of(1L),
+                UserId.of(100L),
+                UserId.of(200L),
+                ChatRoomContext.forPlace(12345L, "강남 스터디룸 A")
+        )
+
+        chatRoomRepository.findPlaceInquiriesByHostId(UserId.of(200L), null) >> [chatRoom]
+        messageRepository.countUnreadByRoomIdAndUserId(_, _) >> 3L
+
+        when:
+        def result = service.execute(query)
+
+        then:
+        result.inquiries().size() == 1
+        result.inquiries()[0].guestId() == 100L
+        result.inquiries()[0].context().contextId() == 12345L
+        result.inquiries()[0].unreadCount() == 3
+    }
+
+    def "placeId로 필터링하여 조회한다"() {
+        given:
+        def query = GetHostInquiriesQuery.of(200L, 12345L)
+        def chatRoom = ChatRoom.createPlaceInquiry(
+                RoomId.of(1L),
+                UserId.of(100L),
+                UserId.of(200L),
+                ChatRoomContext.forPlace(12345L, "강남 스터디룸 A")
+        )
+
+        chatRoomRepository.findPlaceInquiriesByHostId(UserId.of(200L), 12345L) >> [chatRoom]
+        messageRepository.countUnreadByRoomIdAndUserId(_, _) >> 0L
+
+        when:
+        def result = service.execute(query)
+
+        then:
+        result.inquiries().size() == 1
+        result.inquiries()[0].context().contextId() == 12345L
+    }
+
+    def "문의가 없으면 빈 목록을 반환한다"() {
+        given:
+        def query = GetHostInquiriesQuery.of(200L)
+
+        chatRoomRepository.findPlaceInquiriesByHostId(UserId.of(200L), null) >> []
+
+        when:
+        def result = service.execute(query)
+
+        then:
+        result.inquiries().isEmpty()
+        result.hasMore() == false
+        result.nextCursor() == null
+    }
+
+    def "limit보다 많은 결과가 있으면 hasMore가 true이다"() {
+        given:
+        def query = GetHostInquiriesQuery.of(200L, null, null, 1)
+        def chatRoom1 = ChatRoom.createPlaceInquiry(
+                RoomId.of(1L),
+                UserId.of(100L),
+                UserId.of(200L),
+                ChatRoomContext.forPlace(12345L, "스터디룸 A")
+        )
+        def chatRoom2 = ChatRoom.createPlaceInquiry(
+                RoomId.of(2L),
+                UserId.of(101L),
+                UserId.of(200L),
+                ChatRoomContext.forPlace(12346L, "스터디룸 B")
+        )
+
+        chatRoomRepository.findPlaceInquiriesByHostId(UserId.of(200L), null) >> [chatRoom1, chatRoom2]
+        messageRepository.countUnreadByRoomIdAndUserId(_, _) >> 0L
+
+        when:
+        def result = service.execute(query)
+
+        then:
+        result.inquiries().size() == 1
+        result.hasMore() == true
+        result.nextCursor() != null
+    }
+
+    def "hostId가 null이면 예외가 발생한다"() {
+        when:
+        GetHostInquiriesQuery.of(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomContextSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/domain/chatroom/ChatRoomContextSpec.groovy
@@ -1,0 +1,102 @@
+package com.teambind.co.kr.chatdding.domain.chatroom
+
+import spock.lang.Specification
+
+class ChatRoomContextSpec extends Specification {
+
+    def "forPlace()로 공간 컨텍스트를 생성할 수 있다"() {
+        when:
+        def context = ChatRoomContext.forPlace(12345L, "강남 스터디룸 A")
+
+        then:
+        context.contextType() == ContextType.PLACE
+        context.contextId() == 12345L
+        context.contextName() == "강남 스터디룸 A"
+        context.metadata().isEmpty()
+    }
+
+    def "forPlace()에 메타데이터를 포함하여 생성할 수 있다"() {
+        given:
+        def metadata = [category: "스터디룸", floor: 3]
+
+        when:
+        def context = ChatRoomContext.forPlace(12345L, "강남 스터디룸 A", metadata)
+
+        then:
+        context.contextType() == ContextType.PLACE
+        context.contextId() == 12345L
+        context.metadata().size() == 2
+        context.metadata()["category"] == "스터디룸"
+    }
+
+    def "forOrder()로 주문 컨텍스트를 생성할 수 있다"() {
+        when:
+        def context = ChatRoomContext.forOrder(999L, "주문 #999")
+
+        then:
+        context.contextType() == ContextType.ORDER
+        context.contextId() == 999L
+        context.contextName() == "주문 #999"
+    }
+
+    def "forBooking()으로 예약 컨텍스트를 생성할 수 있다"() {
+        when:
+        def context = ChatRoomContext.forBooking(888L, "예약 #888")
+
+        then:
+        context.contextType() == ContextType.BOOKING
+        context.contextId() == 888L
+        context.contextName() == "예약 #888"
+    }
+
+    def "isPlaceContext()는 PLACE 타입일 때만 true를 반환한다"() {
+        expect:
+        ChatRoomContext.forPlace(1L, "테스트").isPlaceContext() == true
+        ChatRoomContext.forOrder(1L, "테스트").isPlaceContext() == false
+        ChatRoomContext.forBooking(1L, "테스트").isPlaceContext() == false
+    }
+
+    def "contextType이 null이면 예외가 발생한다"() {
+        when:
+        new ChatRoomContext(null, 1L, "테스트", [:])
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "contextId가 null이면 예외가 발생한다"() {
+        when:
+        new ChatRoomContext(ContextType.PLACE, null, "테스트", [:])
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "contextId가 0 이하이면 예외가 발생한다"() {
+        when:
+        new ChatRoomContext(ContextType.PLACE, 0L, "테스트", [:])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "metadata가 null이면 빈 맵으로 초기화된다"() {
+        when:
+        def context = new ChatRoomContext(ContextType.PLACE, 1L, "테스트", null)
+
+        then:
+        context.metadata() != null
+        context.metadata().isEmpty()
+    }
+
+    def "metadata는 불변이다"() {
+        given:
+        def context = ChatRoomContext.forPlace(1L, "테스트", [key: "value"])
+
+        when:
+        context.metadata().put("newKey", "newValue")
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+}


### PR DESCRIPTION
## Summary
공간(Place) 문의 채팅 기능을 구현했습니다. 호스트가 여러 공간을 운영할 때, 게스트가 특정 공간에 대해 문의하면 해당 공간 정보가 채팅방에 연결됩니다.

## Changes

### Domain Layer
- `ContextType` enum 추가 (PLACE, ORDER, BOOKING)
- `ChatRoomContext` record 추가 (컨텍스트 정보 저장)
- `ChatRoomType.PLACE_INQUIRY` 추가
- `ChatRoom.createPlaceInquiry()` 팩토리 메서드 추가
- `InquiryCreatedEvent` 도메인 이벤트 추가

### Application Layer
- `CreatePlaceInquiryUseCase` - 공간 문의 생성
- `GetHostInquiriesUseCase` - 호스트 문의 목록 조회
- 중복 문의 방지 로직 구현

### Infrastructure Layer
- `ChatRoomContextDocument` MongoDB 문서 추가
- 공간 문의 관련 쿼리 메서드 구현

### Web Adapter Layer
- `POST /api/v1/chat/inquiry` - 공간 문의 생성
- `GET /api/v1/chat/inquiry/host` - 호스트 문의 목록

## Test Coverage
- 34개 신규 테스트 케이스 추가
- 전체 테스트 통과 확인

## Related Issues
- Closes #47 (Epic)
- Closes #48, #49, #50, #51 (Stories)
- Closes #52-#67 (Tasks)