### PR TITLE
Story #71: 안읽은 메시지 수(Unread Count) 캐싱 구현

### DIFF
--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/out/UnreadCountCachePort.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/port/out/UnreadCountCachePort.java
@@ -1,0 +1,60 @@
+package com.teambind.co.kr.chatdding.application.port.out;
+
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 안읽은 메시지 수 캐시 Port (Outbound)
+ *
+ * <p>Hexagonal Architecture의 Outbound Port</p>
+ * <p>Redis 캐시를 통한 안읽은 메시지 수 관리</p>
+ */
+public interface UnreadCountCachePort {
+
+    /**
+     * 안읽은 메시지 수 조회
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @return 캐시된 안읽은 메시지 수 (캐시 미스 시 Optional.empty())
+     */
+    Optional<Integer> getUnreadCount(RoomId roomId, UserId userId);
+
+    /**
+     * 안읽은 메시지 수 설정
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @param count  안읽은 메시지 수
+     */
+    void setUnreadCount(RoomId roomId, UserId userId, int count);
+
+    /**
+     * 안읽은 메시지 수 증가 (+1)
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     */
+    void incrementUnreadCount(RoomId roomId, UserId userId);
+
+    /**
+     * 안읽은 메시지 수 초기화 (읽음 처리)
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     */
+    void resetUnreadCount(RoomId roomId, UserId userId);
+
+    /**
+     * 여러 채팅방의 안읽은 메시지 수 일괄 조회
+     *
+     * @param roomIds 채팅방 ID 목록
+     * @param userId  사용자 ID
+     * @return 채팅방 ID와 안읽은 메시지 수 맵 (캐시 히트된 항목만 포함)
+     */
+    Map<RoomId, Integer> getUnreadCounts(List<RoomId> roomIds, UserId userId);
+}

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetChatRoomsService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/GetChatRoomsService.java
@@ -3,8 +3,11 @@ package com.teambind.co.kr.chatdding.application.service;
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsQuery;
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsResult;
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsUseCase;
+import com.teambind.co.kr.chatdding.application.port.out.UnreadCountCachePort;
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository;
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
 import com.teambind.co.kr.chatdding.domain.message.Message;
 import com.teambind.co.kr.chatdding.domain.message.MessageRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 채팅방 목록 조회 UseCase 구현
@@ -23,28 +27,46 @@ public class GetChatRoomsService implements GetChatRoomsUseCase {
 
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
+    private final UnreadCountCachePort unreadCountCachePort;
 
     @Override
     public GetChatRoomsResult execute(GetChatRoomsQuery query) {
         List<ChatRoom> chatRooms = chatRoomRepository
                 .findActiveByParticipantUserIdOrderByLastMessageAtDesc(query.userId());
 
+        List<RoomId> roomIds = chatRooms.stream()
+                .map(ChatRoom::getId)
+                .toList();
+
+        Map<RoomId, Integer> cachedUnreadCounts = unreadCountCachePort.getUnreadCounts(roomIds, query.userId());
+
         List<GetChatRoomsResult.ChatRoomItem> items = chatRooms.stream()
-                .map(chatRoom -> buildChatRoomItem(chatRoom, query))
+                .map(chatRoom -> buildChatRoomItem(chatRoom, query, cachedUnreadCounts))
                 .toList();
 
         return new GetChatRoomsResult(items);
     }
 
-    private GetChatRoomsResult.ChatRoomItem buildChatRoomItem(ChatRoom chatRoom, GetChatRoomsQuery query) {
+    private GetChatRoomsResult.ChatRoomItem buildChatRoomItem(
+            ChatRoom chatRoom,
+            GetChatRoomsQuery query,
+            Map<RoomId, Integer> cachedUnreadCounts
+    ) {
         Message lastMessage = messageRepository.findLatestByRoomId(chatRoom.getId())
                 .orElse(null);
 
-        long unreadCount = messageRepository.countUnreadByRoomIdAndUserId(
-                chatRoom.getId(),
-                query.userId()
-        );
+        long unreadCount = getUnreadCountWithCacheAside(chatRoom.getId(), query.userId(), cachedUnreadCounts);
 
         return GetChatRoomsResult.ChatRoomItem.from(chatRoom, lastMessage, unreadCount);
+    }
+
+    private long getUnreadCountWithCacheAside(RoomId roomId, UserId userId, Map<RoomId, Integer> cachedCounts) {
+        if (cachedCounts.containsKey(roomId)) {
+            return cachedCounts.get(roomId);
+        }
+
+        long count = messageRepository.countUnreadByRoomIdAndUserId(roomId, userId);
+        unreadCountCachePort.setUnreadCount(roomId, userId, (int) count);
+        return count;
     }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/MarkAsReadService.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/application/service/MarkAsReadService.java
@@ -3,6 +3,7 @@ package com.teambind.co.kr.chatdding.application.service;
 import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadCommand;
 import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadResult;
 import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadUseCase;
+import com.teambind.co.kr.chatdding.application.port.out.UnreadCountCachePort;
 import com.teambind.co.kr.chatdding.common.exception.ChatException;
 import com.teambind.co.kr.chatdding.common.exception.ErrorCode;
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom;
@@ -27,6 +28,7 @@ public class MarkAsReadService implements MarkAsReadUseCase {
 
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
+    private final UnreadCountCachePort unreadCountCachePort;
 
     @Override
     public MarkAsReadResult execute(MarkAsReadCommand command) {
@@ -37,6 +39,7 @@ public class MarkAsReadService implements MarkAsReadUseCase {
         int readCount = markMessagesAsRead(unreadMessages, command, readAt);
 
         updateParticipantLastReadAt(chatRoom, command, readAt);
+        resetUnreadCountCache(command);
 
         return MarkAsReadResult.of(
                 command.roomId().toStringValue(),
@@ -93,5 +96,9 @@ public class MarkAsReadService implements MarkAsReadUseCase {
                     participant.updateLastReadAt(readAt);
                     chatRoomRepository.save(chatRoom);
                 });
+    }
+
+    private void resetUnreadCountCache(MarkAsReadCommand command) {
+        unreadCountCachePort.resetUnreadCount(command.roomId(), command.userId());
     }
 }

--- a/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/cache/redis/UnreadCountRedisAdapter.java
+++ b/ChatDDing-service/src/main/java/com/teambind/co/kr/chatdding/infrastructure/cache/redis/UnreadCountRedisAdapter.java
@@ -1,0 +1,116 @@
+package com.teambind.co.kr.chatdding.infrastructure.cache.redis;
+
+import com.teambind.co.kr.chatdding.application.port.out.UnreadCountCachePort;
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId;
+import com.teambind.co.kr.chatdding.domain.common.UserId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redis 기반 안읽은 메시지 수 캐시 Adapter
+ *
+ * <p>Cache-Aside 패턴 적용</p>
+ * <p>Graceful Degradation: Redis 장애 시 Optional.empty() 반환하여 DB 조회 유도</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UnreadCountRedisAdapter implements UnreadCountCachePort {
+
+    private static final String KEY_PREFIX = "unread:";
+    private static final long TTL_HOURS = 24;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public Optional<Integer> getUnreadCount(RoomId roomId, UserId userId) {
+        try {
+            String key = buildKey(roomId, userId);
+            Object value = redisTemplate.opsForValue().get(key);
+            return Optional.ofNullable(value)
+                    .map(v -> ((Number) v).intValue());
+        } catch (Exception e) {
+            log.warn("Redis getUnreadCount failed, returning empty. key=unread:{}:{}, error={}",
+                    roomId.toStringValue(), userId.getValue(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void setUnreadCount(RoomId roomId, UserId userId, int count) {
+        try {
+            String key = buildKey(roomId, userId);
+            redisTemplate.opsForValue().set(key, count, TTL_HOURS, TimeUnit.HOURS);
+            log.debug("Cache set: {}={}", key, count);
+        } catch (Exception e) {
+            log.warn("Redis setUnreadCount failed. key=unread:{}:{}, count={}, error={}",
+                    roomId.toStringValue(), userId.getValue(), count, e.getMessage());
+        }
+    }
+
+    @Override
+    public void incrementUnreadCount(RoomId roomId, UserId userId) {
+        try {
+            String key = buildKey(roomId, userId);
+            Long newValue = redisTemplate.opsForValue().increment(key);
+            redisTemplate.expire(key, TTL_HOURS, TimeUnit.HOURS);
+            log.debug("Cache incremented: {}={}", key, newValue);
+        } catch (Exception e) {
+            log.warn("Redis incrementUnreadCount failed. key=unread:{}:{}, error={}",
+                    roomId.toStringValue(), userId.getValue(), e.getMessage());
+        }
+    }
+
+    @Override
+    public void resetUnreadCount(RoomId roomId, UserId userId) {
+        try {
+            String key = buildKey(roomId, userId);
+            redisTemplate.opsForValue().set(key, 0, TTL_HOURS, TimeUnit.HOURS);
+            log.debug("Cache reset: {}=0", key);
+        } catch (Exception e) {
+            log.warn("Redis resetUnreadCount failed. key=unread:{}:{}, error={}",
+                    roomId.toStringValue(), userId.getValue(), e.getMessage());
+        }
+    }
+
+    @Override
+    public Map<RoomId, Integer> getUnreadCounts(List<RoomId> roomIds, UserId userId) {
+        Map<RoomId, Integer> result = new HashMap<>();
+
+        try {
+            List<String> keys = roomIds.stream()
+                    .map(roomId -> buildKey(roomId, userId))
+                    .toList();
+
+            List<Object> values = redisTemplate.opsForValue().multiGet(keys);
+
+            if (values != null) {
+                for (int i = 0; i < roomIds.size(); i++) {
+                    Object value = values.get(i);
+                    if (value != null) {
+                        result.put(roomIds.get(i), ((Number) value).intValue());
+                    }
+                }
+            }
+
+            log.debug("Cache multiGet: {} keys requested, {} hits", roomIds.size(), result.size());
+        } catch (Exception e) {
+            log.warn("Redis getUnreadCounts failed, returning empty map. userId={}, error={}",
+                    userId.getValue(), e.getMessage());
+        }
+
+        return result;
+    }
+
+    private String buildKey(RoomId roomId, UserId userId) {
+        return KEY_PREFIX + roomId.toStringValue() + ":" + userId.getValue();
+    }
+}

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/GetChatRoomsServiceSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/GetChatRoomsServiceSpec.groovy
@@ -1,6 +1,7 @@
 package com.teambind.co.kr.chatdding.application.service
 
 import com.teambind.co.kr.chatdding.application.port.in.GetChatRoomsQuery
+import com.teambind.co.kr.chatdding.application.port.out.UnreadCountCachePort
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoomRepository
 import com.teambind.co.kr.chatdding.domain.chatroom.RoomId
@@ -15,14 +16,20 @@ class GetChatRoomsServiceSpec extends Specification {
 
     ChatRoomRepository chatRoomRepository = Mock()
     MessageRepository messageRepository = Mock()
+    UnreadCountCachePort unreadCountCachePort = Mock()
 
     @Subject
     GetChatRoomsService getChatRoomsService = new GetChatRoomsService(
             chatRoomRepository,
-            messageRepository
+            messageRepository,
+            unreadCountCachePort
     )
 
     def userId = UserId.of(100L)
+
+    def setup() {
+        unreadCountCachePort.getUnreadCounts(_, _) >> [:]
+    }
 
     def "채팅방 목록을 조회할 수 있다"() {
         given:

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/MarkAsReadServiceSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/MarkAsReadServiceSpec.groovy
@@ -1,6 +1,7 @@
 package com.teambind.co.kr.chatdding.application.service
 
 import com.teambind.co.kr.chatdding.application.port.in.MarkAsReadCommand
+import com.teambind.co.kr.chatdding.application.port.out.UnreadCountCachePort
 import com.teambind.co.kr.chatdding.common.exception.ChatException
 import com.teambind.co.kr.chatdding.common.exception.ErrorCode
 import com.teambind.co.kr.chatdding.domain.chatroom.ChatRoom
@@ -17,11 +18,13 @@ class MarkAsReadServiceSpec extends Specification {
 
     ChatRoomRepository chatRoomRepository = Mock()
     MessageRepository messageRepository = Mock()
+    UnreadCountCachePort unreadCountCachePort = Mock()
 
     @Subject
     MarkAsReadService markAsReadService = new MarkAsReadService(
             chatRoomRepository,
-            messageRepository
+            messageRepository,
+            unreadCountCachePort
     )
 
     def roomId = RoomId.of(1L)

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/SendMessageServiceSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/application/service/SendMessageServiceSpec.groovy
@@ -2,6 +2,7 @@ package com.teambind.co.kr.chatdding.application.service
 
 import com.teambind.co.kr.chatdding.application.port.in.SendMessageCommand
 import com.teambind.co.kr.chatdding.application.port.out.EventPublisher
+import com.teambind.co.kr.chatdding.application.port.out.UnreadCountCachePort
 import com.teambind.co.kr.chatdding.common.exception.ChatException
 import com.teambind.co.kr.chatdding.common.exception.ErrorCode
 import com.teambind.co.kr.chatdding.common.util.generator.PrimaryKeyGenerator
@@ -22,13 +23,15 @@ class SendMessageServiceSpec extends Specification {
     MessageRepository messageRepository = Mock()
     PrimaryKeyGenerator primaryKeyGenerator = Mock()
     EventPublisher eventPublisher = Mock()
+    UnreadCountCachePort unreadCountCachePort = Mock()
 
     @Subject
     SendMessageService sendMessageService = new SendMessageService(
             chatRoomRepository,
             messageRepository,
             primaryKeyGenerator,
-            eventPublisher
+            eventPublisher,
+            unreadCountCachePort
     )
 
     def roomId = RoomId.of(1L)

--- a/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/infrastructure/cache/redis/UnreadCountRedisAdapterSpec.groovy
+++ b/ChatDDing-service/src/test/groovy/com/teambind/co/kr/chatdding/infrastructure/cache/redis/UnreadCountRedisAdapterSpec.groovy
@@ -1,0 +1,139 @@
+package com.teambind.co.kr.chatdding.infrastructure.cache.redis
+
+import com.teambind.co.kr.chatdding.domain.chatroom.RoomId
+import com.teambind.co.kr.chatdding.domain.common.UserId
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import spock.lang.Specification
+import spock.lang.Subject
+
+class UnreadCountRedisAdapterSpec extends Specification {
+
+    RedisTemplate<String, Object> redisTemplate = Mock()
+    ValueOperations<String, Object> valueOperations = Mock()
+
+    @Subject
+    UnreadCountRedisAdapter adapter = new UnreadCountRedisAdapter(redisTemplate)
+
+    def roomId = RoomId.of(123L)
+    def userId = UserId.of(456L)
+    def expectedKey = "unread:123:456"
+
+    def setup() {
+        redisTemplate.opsForValue() >> valueOperations
+    }
+
+    def "getUnreadCount - 캐시 히트 시 값 반환"() {
+        given:
+        valueOperations.get(expectedKey) >> 5
+
+        when:
+        def result = adapter.getUnreadCount(roomId, userId)
+
+        then:
+        result.isPresent()
+        result.get() == 5
+    }
+
+    def "getUnreadCount - 캐시 미스 시 Optional.empty 반환"() {
+        given:
+        valueOperations.get(expectedKey) >> null
+
+        when:
+        def result = adapter.getUnreadCount(roomId, userId)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "getUnreadCount - Redis 장애 시 Optional.empty 반환 (Graceful Degradation)"() {
+        given:
+        valueOperations.get(expectedKey) >> { throw new RuntimeException("Redis connection failed") }
+
+        when:
+        def result = adapter.getUnreadCount(roomId, userId)
+
+        then:
+        result.isEmpty()
+        noExceptionThrown()
+    }
+
+    def "setUnreadCount - 값 저장 및 TTL 설정"() {
+        when:
+        adapter.setUnreadCount(roomId, userId, 10)
+
+        then:
+        1 * valueOperations.set(expectedKey, 10, 24, _)
+    }
+
+    def "setUnreadCount - Redis 장애 시 예외 전파 없음"() {
+        given:
+        valueOperations.set(_, _, _, _) >> { throw new RuntimeException("Redis write failed") }
+
+        when:
+        adapter.setUnreadCount(roomId, userId, 10)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "incrementUnreadCount - 값 1 증가"() {
+        when:
+        adapter.incrementUnreadCount(roomId, userId)
+
+        then:
+        1 * valueOperations.increment(expectedKey)
+        1 * redisTemplate.expire(expectedKey, 24, _)
+    }
+
+    def "incrementUnreadCount - Redis 장애 시 예외 전파 없음"() {
+        given:
+        valueOperations.increment(_) >> { throw new RuntimeException("Redis increment failed") }
+
+        when:
+        adapter.incrementUnreadCount(roomId, userId)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "resetUnreadCount - 값 0으로 설정"() {
+        when:
+        adapter.resetUnreadCount(roomId, userId)
+
+        then:
+        1 * valueOperations.set(expectedKey, 0, 24, _)
+    }
+
+    def "getUnreadCounts - 여러 키 일괄 조회"() {
+        given:
+        def roomId1 = RoomId.of(1L)
+        def roomId2 = RoomId.of(2L)
+        def roomId3 = RoomId.of(3L)
+        def roomIds = [roomId1, roomId2, roomId3]
+
+        valueOperations.multiGet(_) >> [5, null, 10]
+
+        when:
+        def result = adapter.getUnreadCounts(roomIds, userId)
+
+        then:
+        result.size() == 2
+        result.get(roomId1) == 5
+        result.get(roomId3) == 10
+        !result.containsKey(roomId2)
+    }
+
+    def "getUnreadCounts - Redis 장애 시 빈 맵 반환"() {
+        given:
+        def roomIds = [RoomId.of(1L), RoomId.of(2L)]
+        valueOperations.multiGet(_) >> { throw new RuntimeException("Redis multiGet failed") }
+
+        when:
+        def result = adapter.getUnreadCounts(roomIds, userId)
+
+        then:
+        result.isEmpty()
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
## Summary
- Redis 캐싱 시스템을 통한 안읽은 메시지 수 관리 구현
- Cache-Aside 패턴 적용으로 캐시 미스 시 DB 조회 및 자동 캐싱
- Graceful Degradation으로 Redis 장애 시에도 서비스 정상 동작

## Changes

### Infrastructure Layer
- `UnreadCountCachePort`: 캐시 아웃바운드 포트 인터페이스
- `UnreadCountRedisAdapter`: Redis 기반 캐시 어댑터 구현

### Application Layer
- `SendMessageService`: 메시지 전송 시 수신자 unread count 증가
- `MarkAsReadService`: 읽음 처리 시 unread count 리셋
- `GetChatRoomsService`: Cache-Aside 패턴으로 unread count 조회

### Tests
- `UnreadCountRedisAdapterSpec`: Redis 어댑터 단위 테스트
- 기존 서비스 테스트에 캐시 포트 Mock 추가

## Cache Design
- **Key Pattern**: `unread:{roomId}:{userId}`
- **TTL**: 24시간
- **Graceful Degradation**: Redis 장애 시 예외 전파 없이 로그만 남기고 DB 조회

## Test Plan
- [x] UnreadCountRedisAdapter 단위 테스트
- [x] SendMessageService 테스트 통과
- [x] MarkAsReadService 테스트 통과
- [x] GetChatRoomsService 테스트 통과
- [x] 빌드 성공

## Related Issues
- Closes #72, #73, #74, #75, #76, #77, #78
- Part of Epic #70